### PR TITLE
[박상욱] sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,8 @@
           <span class="copyright">©codeit - 2024</span>
           <div class="center_nav">
             <a class="cursor" href="/privacy">Privacy Policy</a>
+          </div>
+          <div class="center_nav">
             <a class="cursor" href="/faq">FAQ</a>
           </div>
           <div class="sns_link">

--- a/index.html
+++ b/index.html
@@ -2,8 +2,17 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1"
+    />
     <title>판다마켓</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Abel&display=swap"
+      rel="stylesheet"
+    />
     <link
       rel="stylesheet"
       as="style"
@@ -23,11 +32,10 @@
       </header>
       <section class="home gnb_margin">
         <div class="container">
-          <h2 class="title">
-            일상의 모든 물건을<br />
-            거래해 보세요
-          </h2>
-          <a class="view_more btn cursor" href="/items">구경하러 가기</a>
+          <div class="content_box">
+            <h2 class="title">일상의 모든 물건을 거래해 보세요</h2>
+            <a class="view_more btn cursor" href="/items">구경하러 가기</a>
+          </div>
           <img
             class="home_img"
             alt="상단 이미지"
@@ -45,7 +53,7 @@
             />
             <div class="main_content">
               <span class="category">Hot item</span>
-              <h2 class="subtitle">인기 상품을<br />확인해 보세요</h2>
+              <h2 class="subtitle">인기 상품을 확인해 보세요</h2>
               <span class="description"
                 >가장 hot한 중고거래 물품을<br />
                 판다 마켓에서 확인해 보세요</span
@@ -55,7 +63,7 @@
           <section class="search">
             <div class="main_content">
               <span class="category">Search</span>
-              <h2 class="subtitle">구매를 원하는<br />상품을 검색하세요</h2>
+              <h2 class="subtitle">구매를 원하는 상품을 검색하세요</h2>
               <span class="description"
                 >구매하고 싶은 물품은 검색해서<br />
                 쉽게 찾아보세요</span
@@ -75,7 +83,7 @@
             />
             <div class="main_content">
               <span class="category">Register</span>
-              <h2 class="subtitle">판매를 원하는<br />상품을 등록하세요</h2>
+              <h2 class="subtitle">판매를 원하는 상품을 등록하세요</h2>
               <span class="description"
                 >어떤 물건이든 판매하고 싶은 상품을<br />
                 쉽게 등록하세요</span
@@ -84,7 +92,7 @@
           </section>
         </div>
       </main>
-      <section class="home">
+      <section class="home bottom">
         <div class="container">
           <h2 class="title">
             믿을 수 있는<br />

--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@
             거래해 보세요
           </h2>
           <a class="view_more btn cursor" href="/items">구경하러 가기</a>
+          <img
+            class="home_img"
+            alt="상단 이미지"
+            src="./images/Img_home_top.png"
+          />
         </div>
-        <img
-          class="home_img"
-          alt="상단 이미지"
-          src="./images/Img_home_top.png"
-        />
       </section>
       <main>
         <div class="container">
@@ -90,12 +90,12 @@
             믿을 수 있는<br />
             판다마켓 중고거래
           </h2>
+          <img
+            class="home_img home_bottom"
+            alt="하단 이미지"
+            src="./images/Img_home_bottom.png"
+          />
         </div>
-        <img
-          class="home_img home_bottom"
-          alt="하단 이미지"
-          src="./images/Img_home_bottom.png"
-        />
       </section>
       <footer>
         <div class="footer_nav">

--- a/login.html
+++ b/login.html
@@ -28,7 +28,7 @@
         <section class="main_content">
           <form class="form">
             <label for="email">
-              <p class="login_label">이메일</p>
+              <span class="login_label">이메일</span>
               <input
                 class="input_box"
                 type="email"
@@ -38,7 +38,7 @@
               />
             </label>
             <label for="password">
-              <p class="login_label">비밀번호</p>
+              <span class="login_label">비밀번호</span>
               <div class="passowrd_container">
                 <input
                   class="input_box"

--- a/signup.html
+++ b/signup.html
@@ -28,7 +28,7 @@
         <section class="main_content">
           <form class="form">
             <label for="email">
-              <p class="login_label">이메일</p>
+              <span class="login_label">이메일</span>
               <input
                 class="input_box"
                 type="email"
@@ -37,7 +37,7 @@
                 placeholder="이메일을 입력해주세요"
               /> </label
             ><label for="username">
-              <p class="login_label">닉네임</p>
+              <span class="login_label">닉네임</span>
               <input
                 class="input_box"
                 type="text"
@@ -47,7 +47,7 @@
               />
             </label>
             <label for="password">
-              <p class="login_label">비밀번호</p>
+              <span class="login_label">비밀번호</span>
               <div class="passowrd_container">
                 <input
                   class="input_box"
@@ -64,7 +64,7 @@
                 />
               </div> </label
             ><label for="check_password">
-              <p class="login_label">비밀번호 확인</p>
+              <span class="login_label">비밀번호 확인</span>
               <div class="passowrd_container">
                 <input
                   class="input_box"

--- a/style.css
+++ b/style.css
@@ -35,19 +35,19 @@
 }
 
 html {
-  font-family: Pretendard, sans-serif;
+  font-family: "Pretendard", "Abel", sans-serif;
   word-break: keep-all;
   font-size: 62.5%;
 }
 
 body {
-  background-color: var(--gray900);
+  background-color: #fff;
   color: var(--gray700);
   margin: 0;
 }
 
 .wrap {
-  /* max-width: 1920px; */
+  max-width: 100%;
   width: 100%;
   margin: 0 auto;
 }
@@ -131,12 +131,18 @@ header .login {
 }
 
 .home .container {
-  align-items: center;
   flex-direction: column;
   gap: 32px;
   justify-content: center;
   align-items: flex-start;
   position: relative;
+}
+
+.home .content_box {
+  width: 357px;
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
 }
 
 .home .title {
@@ -187,6 +193,21 @@ main section {
   width: 588px;
   height: 444px;
   flex: none;
+}
+
+.hot_item .main_content {
+  width: 274px;
+  height: 238px;
+}
+
+.search .main_content {
+  width: 317px;
+  height: 238px;
+}
+
+.register .main_content {
+  width: 335px;
+  height: 238px;
 }
 
 main .category {
@@ -254,4 +275,102 @@ footer .cursor {
   width: 20px;
   height: 20px;
   display: block;
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+  header {
+    padding: 0 24px;
+  }
+
+  .container {
+    width: 100%;
+  }
+
+  .home {
+    height: 771px;
+  }
+
+  .home .container {
+    align-items: center;
+    flex-direction: column;
+    padding-top: 84px;
+    justify-content: space-between;
+    position: relative;
+    text-align: center;
+  }
+
+  .home .content_box {
+    width: 100%;
+    align-items: center;
+  }
+
+  .btn {
+    width: 357px;
+  }
+
+  .home_img {
+    position: static;
+    width: 744px;
+    height: 340px;
+  }
+
+  main .container {
+    margin: 24px auto;
+    gap: 52px;
+    width: 696px;
+  }
+
+  main section {
+    flex-direction: column;
+    height: 708px;
+    gap: 24px;
+  }
+
+  main .container .main_content {
+    height: 160px;
+  }
+
+  main .main_img {
+    width: 696px;
+    height: 524px;
+  }
+
+  main .container .main_content {
+    width: 100%;
+  }
+
+  main .container .subtitle {
+    line-height: 4.2rem;
+    font-size: 3.2rem;
+  }
+
+  main .container .description {
+    line-height: 2.6rem;
+    font-size: 1.8rem;
+  }
+
+  main .search {
+    flex-direction: column-reverse;
+  }
+
+  .home.bottom {
+    height: 927px;
+    padding-top: 201px;
+  }
+
+  footer {
+    padding: 32px 104px 108px;
+    font-family: "Abel";
+  }
+
+  footer .copyright {
+    color: #676767;
+  }
+
+  footer .footer_nav {
+    color: #cfcfcf;
+  }
+}
+
+@media (min-width: 375px) and (max-width: 767px) {
 }

--- a/style.css
+++ b/style.css
@@ -367,10 +367,132 @@ footer .cursor {
     color: #676767;
   }
 
-  footer .footer_nav {
+  footer .center_nav {
     color: #cfcfcf;
   }
 }
 
 @media (min-width: 375px) and (max-width: 767px) {
+  header {
+    padding: 0 16px;
+  }
+
+  header .logo_button .logo {
+    display: none;
+  }
+
+  .container {
+    width: 100%;
+  }
+
+  body .wrap .home {
+    height: 540px;
+  }
+
+  .home .container {
+    padding-top: 48px;
+    align-items: center;
+    text-align: center;
+    justify-content: space-between;
+  }
+
+  .home .content_box {
+    width: 240px;
+    align-items: center;
+  }
+
+  .home .title {
+    font-size: 3.2rem;
+    line-height: 4.48rem;
+  }
+
+  .home .content_box .view_more {
+    font-size: 1.8rem;
+    line-height: 2.6rem;
+    padding: 12px 71px;
+  }
+
+  .btn {
+    width: 240px;
+    height: 48px;
+  }
+
+  .home_img {
+    position: static;
+    width: 448px;
+    height: 204px;
+  }
+
+  main .container {
+    margin: 52px auto 83px;
+    gap: 40px;
+    width: 344px;
+  }
+
+  main section {
+    flex-direction: column;
+    height: 417px;
+    gap: 24px;
+  }
+
+  main .container .main_content {
+    height: 160px;
+  }
+
+  main .main_img {
+    width: 100%;
+    height: 259px;
+  }
+
+  main .container .main_content {
+    width: 100%;
+  }
+
+  main .container .category {
+    font-size: 1.6rem;
+  }
+
+  main .container .subtitle {
+    line-height: 3.2rem;
+    font-size: 2.4rem;
+    margin: 8px 0 16px;
+  }
+
+  main .container .description {
+    line-height: 2.6rem;
+    font-size: 1.6rem;
+  }
+
+  main .search {
+    flex-direction: column-reverse;
+  }
+
+  .home.bottom {
+    padding-top: 121px;
+  }
+
+  .home.bottom .home_img {
+    width: 375px;
+    height: 198px;
+  }
+
+  footer {
+    padding: 32px 104px 108px;
+    font-family: Arial;
+  }
+
+  footer .footer_nav {
+    position: relative;
+  }
+
+  footer .copyright {
+    color: #676767;
+    position: absolute;
+    left: 0;
+    top: 60px;
+  }
+
+  footer .center_nav {
+    color: #cfcfcf;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -41,13 +41,13 @@ html {
 }
 
 body {
-  background-color: var(--background-color);
+  background-color: var(--gray900);
   color: var(--gray700);
   margin: 0;
 }
 
 .wrap {
-  max-width: 1920px;
+  /* max-width: 1920px; */
   width: 100%;
   margin: 0 auto;
 }
@@ -60,7 +60,7 @@ body {
 }
 
 header {
-  max-width: 1920px;
+  /* max-width: 1920px; */
   width: 100%;
   height: 70px;
   margin: 0;
@@ -123,7 +123,7 @@ header .login {
 .home {
   width: 100%;
   height: 540px;
-  position: relative;
+  background-color: var(--background-color);
 }
 
 .gnb_margin {
@@ -136,6 +136,7 @@ header .login {
   gap: 32px;
   justify-content: center;
   align-items: flex-start;
+  position: relative;
 }
 
 .home .title {
@@ -155,7 +156,7 @@ header .login {
 
 .home_img {
   position: absolute;
-  left: 701px;
+  right: 0px;
   width: 746px;
   height: 340px;
   bottom: 0;


### PR DESCRIPTION
## Netlify
https://codeit-sprint-fe9-part1-mission.netlify.app/

## 기본 요구사항
- Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- 피그마 디자인에 맞게 페이지를 만들어 주세요.
- React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 체크리스트 [기본]

**공통**

- 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
- [x] PC: 1200px 이상
- [x] Tablet: 768px 이상 ~ 1199px 이하
- [x] Mobile: 375px 이상 ~ 767px 이하
- [x] 375px 미만 사이즈의 디자인은 고려하지 않습니다

**랜딩 페이지**

- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

**로그인, 회원가입 페이지 공통**

- [ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 체크리스트 [심화]

- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.


## 주요 변경사항

- `label`태그  내부의 `p`태그를 `span`태그로 변경
- PC 사이즈에서 어색했던 배경 수정
- Tablet과 Mobile 사이즈의 반응형 디자인 추가

## 스크린샷

![tablet_design](https://github.com/user-attachments/assets/93004f48-4345-4934-8a97-bb8d3e44a473)
![mobile_design](https://github.com/user-attachments/assets/a0672af4-847e-47a2-b064-a6a5f808c09f)

## 멘토에게

- 이번 주는 인터랙티브 JS로 진도도 밀리고 개인 일정도 있었어서 스프린트 미션에 집중을 못 한 것 같습니다.
- FE 과정을 배우면서 스프린트 미션을 진행하다보니 저번주에 만들어둔 코드가 지금보면 난잡하고 수정해야 할 부분도 많이 보이는 것 같습니다. 하나하나 수정하려니 막막하면서 새로 만드는 것이 빠를 것 같다는 생각도 드는데 이런 부분은 차차 숙련도가 쌓이면서 나아지겠죠..?
- 커밋을 뭉텅이로 해버렸는데 다음부터는 기능별로 나눠서 잘  하겠습니다..

