### PR TITLE
[정우영] sprint3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -28,10 +28,10 @@
     </header>
 
     <main>
-      <section id="hero" class="banner">
-        <div class="wrapper">
+      <section class="banner">
+        <div id="wrapper" class="wrapper">
           <h1>
-            일상의 모든 물건을<br />
+            일상의 모든 물건을<br class="feature-br" />
             거래해 보세요
           </h1>
           <a href="items.html" class="button pill-button">구경하러 가기</a>
@@ -41,13 +41,18 @@
       <section id="features" class="wrapper">
         <div class="feature">
           <img
+            class="feature-img"
             src="images/home/feature1-image.png"
             alt="인기 상품"
-            width="50%"
+            width="588px"
+            height="444px"
           />
           <div class="feature-content">
             <h2 class="feature-tag">Hot item</h2>
-            <h1>인기 상품을<br />확인해 보세요</h1>
+            <h1>
+              인기 상품을<br class="feature-br" />
+              확인해 보세요
+            </h1>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
@@ -56,27 +61,37 @@
         <div class="feature">
           <div class="feature-content">
             <h2 class="feature-tag">Search</h2>
-            <h1>구매를 원하는<br />상품을 검색하세요</h1>
+            <h1 class="search-info">
+              구매를 원하는<br class="feature-br" />
+              상품을 검색하세요
+            </h1>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
             </p>
           </div>
           <img
+            class="feature-img"
             src="images/home/feature2-image.png"
             alt="검색 기능"
-            width="50%"
+            width="588px"
+            height="444px"
           />
         </div>
         <div class="feature">
           <img
+            class="feature-img"
             src="images/home/feature3-image.png"
             alt="판매 상품 등록"
-            width="50%"
+            width="588px"
+            height="444px"
           />
           <div class="feature-content">
             <h2 class="feature-tag">Register</h2>
-            <h1>판매를 원하는<br />상품을 등록하세요</h1>
+            <h1>
+              판매를 원하는<br class="feature-br" />
+              상품을 등록하세요
+            </h1>
             <p class="feature-description">
               어떤 물건이든 판매하고 싶은 상품을
               <br />쉽게 등록하세요
@@ -86,7 +101,7 @@
       </section>
 
       <section id="bottomBanner" class="banner">
-        <div class="wrapper">
+        <div id="wrapper" class="wrapper">
           <h1>
             믿을 수 있는
             <br />
@@ -97,12 +112,12 @@
     </main>
 
     <footer>
-      <div>©codeit - 2024</div>
-      <div id="footerMenu">
+      <div class="footer-codeit">©codeit - 2024</div>
+      <div class="footerMenu">
         <a href="privacy.html">Privacy Policy</a>
         <a href="faq.html">FAQ</a>
       </div>
-      <div id="socialMedia">
+      <div class="socialMedia">
         <a
           href="https://www.facebook.com/"
           target="_blank"

--- a/login.html
+++ b/login.html
@@ -11,6 +11,7 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
+    <link rel="stylesheet" href="styles/reset.css" />
     <link rel="stylesheet" href="styles/login.css" />
   </head>
 
@@ -22,13 +23,14 @@
             src="images/logo/panda-market-logo.png"
             alt="판다마켓"
             width="396"
+            height="132"
           />
         </a>
       </h1>
     </header>
 
     <main>
-      <form>
+      <form class="form-wrap">
         <div class="userEmail-wrap">
           <label class="email-label" for="userEmail">이메일</label>
           <input
@@ -39,13 +41,15 @@
         </div>
         <div class="password-wrap">
           <label class="password-label" for="password">비밀번호</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-          />
-          <div class="password-visiblity-button"></div>
+          <div class="input-wrap">
+            <input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="비밀번호를 입력해주세요"
+            />
+            <button type="button" class="password-visiblity-button"></button>
+          </div>
         </div>
         <button class="login-button" type="submit">로그인</button>
       </form>
@@ -53,14 +57,24 @@
         <span>간편 로그인하기</span>
         <div class="social-login">
           <a class="google-link" href="https://www.google.com/" target="_blank">
-            <img src="images/social/google-logo.svg" alt="google" width="42" />
+            <img
+              src="images/social/google-logo.svg"
+              alt="google"
+              width="42"
+              height="42"
+            />
           </a>
           <a
             class="kakao-link"
             href="https://www.kakaocorp.com/page/"
             target="_blank"
           >
-            <img src="images/social/kakao-logo.svg" alt="kakao" width="42" />
+            <img
+              src="images/social/kakao-logo.svg"
+              alt="kakao"
+              width="42"
+              height="42"
+            />
           </a>
         </div>
       </div>

--- a/signup.html
+++ b/signup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>판다마켓 - 로그인</title>
+    <title>판다마켓 - 회원가입</title>
     <link rel="icon" href="images/logo/favicon.ico" />
     <link
       rel="stylesheet"
@@ -11,6 +11,7 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
+    <link rel="stylesheet" href="styles/reset.css" />
     <link rel="stylesheet" href="styles/signup.css" />
   </head>
 
@@ -22,13 +23,14 @@
             src="images/logo/panda-market-logo.png"
             alt="판다마켓"
             width="396"
+            height="132"
           />
         </a>
       </h1>
     </header>
 
     <main>
-      <form>
+      <form class="form-wrap">
         <div class="userEmail-wrap">
           <label class="email-label" for="userEmail">이메일</label>
           <input
@@ -38,7 +40,7 @@
           />
         </div>
         <div class="nickname-wrap">
-          <label class="nickname-label">닉네임</label>
+          <label class="nickname-label" for="nickname">닉네임</label>
           <input
             id="nickname"
             name="nickname"
@@ -47,25 +49,29 @@
         </div>
         <div class="password-wrap">
           <label class="password-label" for="password">비밀번호</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-          />
-          <div class="password-visiblity-button"></div>
+          <div class="input-wrap">
+            <input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="비밀번호를 입력해주세요"
+            />
+            <button class="password-visiblity-button"></button>
+          </div>
         </div>
         <div class="password-check-wrap">
-          <label class="password-check-label" for="password-check">
+          <label class="password-check-label" for="passwordCheck">
             비밀번호 확인
           </label>
-          <input
-            id="passwordCheck"
-            name="passwordCheck"
-            type="password"
-            placeholder="비밀번호를 다시 한 번 입력해주세요"
-          />
-          <div class="password-check-visiblity-button"></div>
+          <div class="input-wrap">
+            <input
+              id="passwordCheck"
+              name="passwordCheck"
+              type="password"
+              placeholder="비밀번호를 다시 한 번 입력해주세요"
+            />
+            <button class="password-check-visiblity-button"></button>
+          </div>
         </div>
         <button class="signup-button" type="submit">회원가입</button>
       </form>
@@ -73,14 +79,24 @@
         <span>간편 로그인하기</span>
         <div class="social-login">
           <a class="google-link" href="https://www.google.com/" target="_blank">
-            <img src="images/social/google-logo.svg" alt="google" width="42" />
+            <img
+              src="images/social/google-logo.svg"
+              alt="google"
+              width="42"
+              height="42"
+            />
           </a>
           <a
             class="kakao-link"
             href="https://www.kakaocorp.com/page/"
             target="_blank"
           >
-            <img src="images/social/kakao-logo.svg" alt="kakao" width="42" />
+            <img
+              src="images/social/kakao-logo.svg"
+              alt="kakao"
+              width="42"
+              height="42"
+            />
           </a>
         </div>
       </div>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,63 +1,520 @@
-.banner {
-  background-color: #cfe5ff;
-  height: 540px;
-  display: flex;
-  align-items: center;
-  background-repeat: no-repeat;
-  background-position: 80% bottom;
-  background-size: 55%;
+/* mobile */
+@media (min-width: 375px) {
+  .banner {
+    padding: 48px 0 336px;
+    background: #cfe5ff url("../images/home/hero-image.png") no-repeat;
+    height: 540px;
+    background-position: center bottom;
+    background-size: 448px 204px;
+  }
+
+  #features {
+    width: 344px;
+    padding: 52px 0 83px 0;
+  }
+
+  #bottomBanner {
+    background-image: url("../images/home/bottom-banner-image.png");
+    padding: 121px 0 329px;
+    background-size: 375px 198px;
+  }
+
+  #loginLinkButton {
+    font-size: 16px;
+    font-weight: 600;
+    border-radius: 8px;
+    padding: 11px 43px;
+  }
+
+  .banner .pill-button {
+    margin-top: 18px;
+  }
+
+  .feature {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    row-gap: 24px;
+  }
+
+  .feature-img {
+    width: 100%;
+    height: auto;
+  }
+
+  .feature:nth-child(2) {
+    padding: 40px 0 40px;
+    text-align: right;
+    flex-direction: column-reverse;
+  }
+
+  .feature-content {
+    margin-right: auto;
+  }
+
+  .feature-br {
+    display: none;
+  }
+
+  .feature:nth-child(2) .feature-content {
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+  .feature-tag {
+    color: #3692ff;
+    font-size: 18px;
+    line-height: 25px;
+    font-weight: 700;
+    margin-bottom: 8px;
+  }
+
+  .feature-description {
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    letter-spacing: 0.08em;
+    margin-top: 16px;
+  }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  button {
+    background: none;
+    border: none;
+    outline: none;
+    box-shadow: none;
+    cursor: pointer;
+  }
+
+  body {
+    color: #374151;
+  }
+
+  header {
+    width: 100%;
+    height: 70px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 16px;
+    background-color: #ffffff;
+    border-bottom: 1px solid #dfdfdf;
+  }
+
+  footer {
+    background-color: #111827;
+    color: #9ca3af;
+    display: grid;
+    padding: 32px;
+    font-size: 16px;
+    grid-template-columns: 181px 116px;
+    grid-template-rows: 18px 18px;
+    row-gap: 60px;
+    column-gap: 13px;
+  }
+
+  .footerMenu {
+    display: flex;
+    gap: 30px;
+    color: #e5e7eb;
+  }
+
+  .socialMedia {
+    display: flex;
+    gap: 12px;
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+  }
+
+  .footer-codeit {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0 auto;
+    width: 240px;
+  }
+
+  h1 {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 44.8px;
+    text-align: center;
+  }
+
+  .button {
+    background-color: #3692ff;
+    color: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .button:hover {
+    background-color: #1967d6;
+  }
+
+  .button:focus {
+    background-color: #1251aa;
+  }
+
+  .button:disabled {
+    background-color: #9ca3af;
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .pill-button {
+    font-size: 18px;
+    font-weight: 600;
+    border-radius: 999px;
+    padding: 11px 71px;
+  }
 }
 
-#hero {
-  background-image: url("../images/home/hero-image.png");
+/* tablet */
+@media (min-width: 768px) {
+  .banner {
+    padding: 84px 0 551px;
+    background-color: #cfe5ff;
+    background-image: url("../images/home/hero-image.png") no-repeat;
+    height: 771px;
+    display: flex;
+    align-items: center;
+    background-size: 100%;
+  }
+
+  #features {
+    width: 100%;
+    padding: 24px 24px 56px;
+  }
+
+  #bottomBanner {
+    background-image: url("../images/home/bottom-banner-image.png");
+    background-size: 100%;
+    height: 927px;
+    padding: 201px 0 614px;
+  }
+
+  #loginLinkButton {
+    font-size: 16px;
+    font-weight: 600;
+    border-radius: 8px;
+    padding: 11px 43px;
+  }
+
+  .banner .pill-button {
+    margin-top: 24px;
+  }
+
+  .feature {
+    display: flex;
+    align-items: center;
+    gap: 5%;
+  }
+
+  .feature-img {
+    width: 100%;
+  }
+
+  .feature:nth-child(2) {
+    text-align: right;
+    padding: 52px 0;
+  }
+
+  .feature-content {
+    margin-top: 24px;
+  }
+
+  .feature-tag {
+    color: #3692ff;
+    font-size: 18px;
+    line-height: 25px;
+    font-weight: 700;
+    margin-bottom: 16px;
+  }
+
+  .feature-description {
+    font-size: 24px;
+    font-weight: 500;
+    line-height: 120%;
+    letter-spacing: 0.08em;
+    margin-top: 24px;
+  }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  button {
+    background: none;
+    border: none;
+    outline: none;
+    box-shadow: none;
+    cursor: pointer;
+  }
+
+  img {
+    vertical-align: bottom;
+  }
+
+  body {
+    color: #374151;
+  }
+
+  header {
+    width: 100%;
+    height: 70px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 24px;
+    background-color: #ffffff;
+    border-bottom: 1px solid #dfdfdf;
+  }
+
+  footer {
+    background-color: #111827;
+    color: #9ca3af;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 32px 104px 108px;
+    font-size: 16px;
+  }
+
+  #footerMenu {
+    display: flex;
+    gap: 30px;
+    color: #e5e7eb;
+  }
+
+  #socialMedia {
+    display: flex;
+    gap: 12px;
+  }
+
+  .wrapper {
+    width: 100%;
+  }
+
+  h1 {
+    font-size: 40px;
+    font-weight: 700;
+    line-height: 56px;
+    letter-spacing: 0.02em;
+  }
+
+  .button {
+    background-color: #3692ff;
+    color: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .button:hover {
+    background-color: #1967d6;
+  }
+
+  .button:focus {
+    background-color: #1251aa;
+  }
+
+  .button:disabled {
+    background-color: #9ca3af;
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .pill-button {
+    font-size: 20px;
+    font-weight: 700;
+    border-radius: 999px;
+    padding: 16px 124px;
+  }
 }
 
-#features {
-  padding-bottom: 138px;
-}
+/* desktop */
+@media (min-width: 1200px) {
+  .banner {
+    background: #cfe5ff url("../images/home/hero-image.png") no-repeat 65%
+      bottom;
+    width: 100%;
+    height: 540px;
+    display: flex;
+    align-items: center;
+    background-size: 746px 340px;
+    padding: 240px 0 100px;
+    position: relative;
+  }
 
-#bottomBanner {
-  background-image: url("../images/home/bottom-banner-image.png");
-}
+  #wrapper {
+    position: absolute;
+    left: -300px;
+  }
 
-#loginLinkButton {
-  font-size: 16px;
-  font-weight: 600;
-  border-radius: 8px;
-  padding: 11.5px 23px;
-}
+  .feature-br {
+    display: unset;
+  }
 
-.banner .pill-button {
-  margin-top: 32px;
-}
+  #features {
+    padding: 138px 0 276px;
+  }
 
-.feature {
-  padding: 138px 0;
-  display: flex;
-  align-items: center;
-  gap: 5%;
-}
+  #bottomBanner {
+    background-image: url("../images/home/bottom-banner-image.png");
+    background-size: 746px 397px;
+    padding: 143px 0 0;
+    height: 540px;
+  }
 
-.feature:nth-child(2) {
-  text-align: right;
-}
+  #loginLinkButton {
+    font-size: 16px;
+    font-weight: 600;
+    border-radius: 8px;
+    padding: 11.5px 23px;
+  }
 
-.feature-content {
-  flex: 1;
-}
+  .banner .pill-button {
+    margin-top: 32px;
+  }
 
-.feature-tag {
-  color: #3692ff;
-  font-size: 18px;
-  line-height: 25px;
-  font-weight: 700;
-  margin-bottom: 12px;
-}
+  .feature {
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 64px;
+  }
 
-.feature-description {
-  font-size: 24px;
-  font-weight: 500;
-  line-height: 120%;
-  letter-spacing: 0.08em;
-  margin-top: 24px;
+  .feature-img {
+    width: 588px;
+    height: 444px;
+  }
+
+  .feature:nth-child(2) {
+    padding: 276px 0;
+    display: flex;
+    flex-direction: row;
+    text-align: right;
+  }
+
+  .feature-tag {
+    color: #3692ff;
+    font-size: 18px;
+    line-height: 25px;
+    font-weight: 700;
+    margin-bottom: 12px;
+  }
+
+  .feature-description {
+    font-size: 24px;
+    font-weight: 500;
+    line-height: 120%;
+    letter-spacing: 0.08em;
+    margin-top: 24px;
+  }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  button {
+    background: none;
+    border: none;
+    outline: none;
+    box-shadow: none;
+    cursor: pointer;
+  }
+
+  img {
+    vertical-align: bottom;
+  }
+
+  body {
+    color: #374151;
+  }
+
+  header {
+    width: 100%;
+    height: 70px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 200px;
+    background-color: #ffffff;
+    border-bottom: 1px solid #dfdfdf;
+  }
+
+  footer {
+    background-color: #111827;
+    color: #9ca3af;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 32px 200px 108px 200px;
+    font-size: 16px;
+  }
+
+  #footerMenu {
+    display: flex;
+    gap: 30px;
+    color: #e5e7eb;
+  }
+
+  #socialMedia {
+    display: flex;
+    gap: 12px;
+  }
+
+  h1 {
+    font-size: 40px;
+    font-weight: 700;
+    line-height: 56px;
+    text-align: left;
+  }
+
+  .search-info {
+    text-align: right;
+  }
+
+  .button {
+    background-color: #3692ff;
+    color: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .button:hover {
+    background-color: #1967d6;
+  }
+
+  .button:focus {
+    background-color: #1251aa;
+  }
+
+  .button:disabled {
+    background-color: #9ca3af;
+    cursor: default;
+    pointer-events: none;
+  }
+
+  .pill-button {
+    font-size: 20px;
+    font-weight: 700;
+    border-radius: 999px;
+    padding: 16px 124px;
+  }
 }

--- a/styles/login.css
+++ b/styles/login.css
@@ -1,165 +1,543 @@
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+/* mobile */
+@media (min-width: 375px) {
+  body {
+    padding: 80px 16px 231px;
+  }
+
+  .panda-logo {
+    display: flex;
+    justify-content: center;
+  }
+
+  .panda-logo-link {
+    display: block;
+    width: 198px;
+    height: 66px;
+  }
+
+  .panda-logo-link img {
+    width: 100%;
+    height: auto;
+  }
+
+  main {
+    margin: 24px auto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 400px;
+  }
+
+  .form-wrap {
+    width: 100%;
+    color: #1f2937;
+  }
+
+  input {
+    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+  }
+
+  input::placeholder {
+    font-size: 16px;
+    line-height: 26px;
+    color: #9ca3af;
+  }
+
+  input:focus {
+    outline: 1px solid #3692ff;
+  }
+
+  .userEmail-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .email-label {
+    width: fit-content;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 24px;
+  }
+
+  #userEmail {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .password-label {
+    width: fit-content;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 24px;
+  }
+
+  .input-wrap {
+    position: relative;
+  }
+
+  #password {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    vertical-align: top;
+    cursor: pointer;
+  }
+
+  .login-button {
+    width: 100%;
+    height: 56px;
+    border-radius: 40px;
+    border-style: none;
+    padding: 16px auto 16px;
+    background-color: #9ca3af;
+    color: #f9fafb;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 32px;
+    text-align: center;
+    margin-bottom: 24px;
+    cursor: pointer;
+  }
+
+  .social-login-wrap {
+    width: 100%;
+    height: 74px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 23px;
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    background-color: #e6f2ff;
+    color: #1f2937;
+    border-radius: 10px;
+  }
+
+  .social-login {
+    display: flex;
+    column-gap: 16px;
+    margin-right: 23px;
+  }
+
+  .google-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .kakao-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .signup-wrap {
+    width: 197px;
+    height: 24px;
+    white-space: nowrap;
+  }
+
+  .guide-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    color: #1f2937;
+  }
+
+  .signup-link {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16.71px;
+  }
 }
 
-body {
-  font-family: "Pretendard", sans-serif;
+/* tablet */
+@media (min-width: 768px) {
+  body {
+    padding: 190px 52px 325px;
+  }
+
+  .panda-logo {
+    display: flex;
+    justify-content: center;
+  }
+
+  .panda-logo-link {
+    display: inline-block;
+    width: 396px;
+    height: 132px;
+  }
+
+  main {
+    margin: 40px auto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: none;
+    width: 640px;
+  }
+
+  .form-wrap {
+    color: #1f2937;
+  }
+
+  input {
+    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+  }
+
+  input::placeholder {
+    font-size: 16px;
+    line-height: 26px;
+    color: #9ca3af;
+  }
+
+  input:focus {
+    outline: 1px solid #3692ff;
+  }
+
+  .userEmail-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .email-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 26px;
+  }
+
+  #userEmail {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .password-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 26px;
+  }
+
+  .input-wrap {
+    position: relative;
+  }
+
+  #password {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    vertical-align: top;
+    cursor: pointer;
+  }
+
+  .login-button {
+    width: 100%;
+    height: 56px;
+    border-radius: 40px;
+    border-style: none;
+    padding: 16px auto 16px;
+    background-color: #9ca3af;
+    color: #f9fafb;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 32px;
+    text-align: center;
+    margin-bottom: 24px;
+    cursor: pointer;
+  }
+
+  .social-login-wrap {
+    width: 100%;
+    height: 74px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 23px;
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    background-color: #e6f2ff;
+    color: #1f2937;
+    border-radius: 10px;
+  }
+
+  .social-login {
+    display: flex;
+    column-gap: 16px;
+    margin-right: 23px;
+  }
+
+  .google-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .kakao-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .signup-wrap {
+    width: 197px;
+    height: 24px;
+    white-space: nowrap;
+  }
+
+  .guide-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    color: #1f2937;
+  }
+
+  .signup-link {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16.71px;
+  }
 }
 
-.panda-logo {
-  display: flex;
-  justify-content: center;
-  margin: 60px auto 0;
-}
+/* desktop */
+@media (min-width: 1200px) {
+  body {
+    padding: 231px 0 231px;
+  }
 
-.panda-logo-link {
-  display: inline-block;
-  width: 396px;
-  height: 132px;
-}
+  .panda-logo {
+    display: flex;
+    justify-content: center;
+  }
 
-main {
-  margin: 40px auto 178px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
+  .panda-logo-link {
+    display: inline-block;
+    width: 396px;
+    height: 132px;
+  }
 
-input {
-  padding-top: 16px;
-  padding-bottom: 14px;
-  padding-left: 24px;
-}
+  main {
+    margin: 40px atuto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 640px;
+  }
 
-input::placeholder {
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 26px;
-  color: #9ca3af;
-}
+  .form-wrap {
+    color: #1f2937;
+  }
 
-input:focus {
-  outline: 1px solid #3692ff;
-}
+  input {
+    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+  }
 
-.userEmail-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-bottom: 24px;
-}
+  input::placeholder {
+    font-size: 16px;
+    line-height: 26px;
+    color: #9ca3af;
+  }
 
-.email-label {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 26px;
-}
+  input:focus {
+    outline: 1px solid #3692ff;
+  }
 
-#userEmail {
-  width: 640px;
-  height: 56px;
-  border-radius: 12px;
-  border-style: none;
-  background-color: #f3f4f6;
-}
+  .userEmail-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
 
-.password-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-bottom: 24px;
-  position: relative;
-}
+  .email-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
 
-.password-label {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 26px;
-}
+  #userEmail {
+    width: 640px;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
 
-#password {
-  width: 640px;
-  height: 56px;
-  border-radius: 12px;
-  border-style: none;
-  background-color: #f3f4f6;
-}
+  .password-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
 
-.password-visiblity-button {
-  background-image: url(/images/form/btn-visibility-off.png);
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  right: 24px;
-  bottom: 16px;
-}
+  .password-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
 
-.login-button {
-  width: 640px;
-  height: 56px;
-  border-radius: 40px;
-  border-style: none;
-  padding: 16px auto 16px;
-  background-color: #9ca3af;
-  color: #f9fafb;
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 32px;
-  text-align: center;
-  margin-bottom: 24px;
-}
+  .input-wrap {
+    position: relative;
+  }
 
-.social-login-wrap {
-  width: 640px;
-  height: 74px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-left: 23px;
-  margin-bottom: 24px;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 26px;
-  background-color: #e6f2ff;
-  color: #1f2937;
-  border-radius: 10px;
-}
+  #password {
+    width: 640px;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
 
-.social-login {
-  display: flex;
-  gap: 16px;
-  margin-right: 23px;
-}
+  .password-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    vertical-align: top;
+    cursor: pointer;
+  }
 
-.google-link {
-  display: inline-block;
-  width: 42px;
-  height: 42px;
-}
+  .login-button {
+    width: 640px;
+    height: 56px;
+    border-radius: 40px;
+    border-style: none;
+    padding: 16px auto 16px;
+    background-color: #9ca3af;
+    color: #f9fafb;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 32px;
+    text-align: center;
+    margin-bottom: 24px;
+    cursor: pointer;
+  }
 
-.kakao-link {
-  display: inline-block;
-  width: 42px;
-  height: 42px;
-}
+  .social-login-wrap {
+    width: 640px;
+    height: 74px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 23px;
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    background-color: #e6f2ff;
+    color: #1f2937;
+    border-radius: 10px;
+  }
 
-.signup-wrap {
-  width: 197px;
-  height: 24px;
-  white-space: nowrap;
-}
+  .social-login {
+    display: flex;
+    column-gap: 16px;
+    margin-right: 23px;
+  }
 
-.guide-text {
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 24px;
-  color: #1f2937;
-}
+  .google-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
 
-.signup-link {
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 16.71px;
+  .kakao-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .signup-wrap {
+    width: 197px;
+    height: 24px;
+    white-space: nowrap;
+  }
+
+  .guide-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    color: #1f2937;
+  }
+
+  .signup-link {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16.71px;
+  }
 }

--- a/styles/reset.css
+++ b/styles/reset.css
@@ -4,99 +4,11 @@
   box-sizing: border-box;
 }
 
-a {
-  text-decoration: none;
-  color: inherit;
-}
-
-button {
-  background: none;
-  border: none;
-  outline: none;
-  box-shadow: none;
-  cursor: pointer;
-}
-
-img {
-  vertical-align: bottom;
-}
-
 body {
-  color: #374151;
-  word-break: keep-all;
   font-family: "Pretendard", sans-serif;
 }
 
-header {
-  width: 100%;
-  height: 70px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0 200px;
-  background-color: #ffffff;
-  border-bottom: 1px solid #dfdfdf;
-}
-
-footer {
-  background-color: #111827;
-  color: #9ca3af;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 32px 200px 108px 200px;
-  font-size: 16px;
-}
-
-#footerMenu {
-  display: flex;
-  gap: 30px;
-  color: #e5e7eb;
-}
-
-#socialMedia {
-  display: flex;
-  gap: 12px;
-}
-
-.wrapper {
-  max-width: 1200px;
-  margin: 0 auto;
-  width: 100%;
-}
-
-h1 {
-  font-size: 40px;
-  font-weight: 700;
-  line-height: 56px;
-  letter-spacing: 0.02em;
-}
-
-.button {
-  background-color: #3692ff;
-  color: #ffffff;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.button:hover {
-  background-color: #1967d6;
-}
-
-.button:focus {
-  background-color: #1251aa;
-}
-
-.button:disabled {
-  background-color: #9ca3af;
-  cursor: default;
-  pointer-events: none;
-}
-
-.pill-button {
-  font-size: 20px;
-  font-weight: 700;
-  border-radius: 999px;
-  padding: 16px 124px;
+img {
+  display: inline-block;
+  vertical-align: top;
 }

--- a/styles/signup.css
+++ b/styles/signup.css
@@ -1,216 +1,717 @@
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+/* mobile */
+@media (min-width: 375px) {
+  body {
+    padding: 24px 16px 179px;
+  }
+
+  .panda-logo {
+    display: flex;
+    justify-content: center;
+  }
+
+  .panda-logo-link {
+    display: block;
+    width: 198px;
+    height: 66px;
+  }
+
+  .panda-logo-link img {
+    width: 100%;
+    height: auto;
+  }
+
+  main {
+    margin: 24px auto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 400px;
+  }
+
+  .form-wrap {
+    width: 100%;
+    color: #1f2937;
+  }
+
+  input {
+    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+  }
+
+  input::placeholder {
+    font-size: 16px;
+    line-height: 26px;
+    color: #9ca3af;
+  }
+
+  input:focus {
+    outline: 1px solid #3692ff;
+  }
+
+  .userEmail-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .email-label {
+    width: fit-content;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 24px;
+  }
+
+  #userEmail {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .nickname-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .nickname-label {
+    width: fit-content;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 24px;
+  }
+
+  #nickname {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .password-label {
+    width: fit-content;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 24px;
+  }
+
+  .input-wrap {
+    position: relative;
+  }
+
+  #password {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    cursor: pointer;
+  }
+
+  .password-check-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+    position: relative;
+  }
+
+  .password-check-label {
+    width: fit-content;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 24px;
+  }
+
+  #passwordCheck {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-check-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    cursor: pointer;
+  }
+
+  .signup-button {
+    width: 100%;
+    height: 56px;
+    border-radius: 40px;
+    border-style: none;
+    padding: 16px auto 16px;
+    background-color: #9ca3af;
+    color: #f9fafb;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 32px;
+    text-align: center;
+    margin-bottom: 24px;
+    cursor: pointer;
+  }
+
+  .social-login-wrap {
+    width: 100%;
+    height: 74px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 23px;
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    background-color: #e6f2ff;
+    color: #1f2937;
+    border-radius: 10px;
+  }
+
+  .social-login {
+    display: flex;
+    column-gap: 16px;
+    margin-right: 23px;
+  }
+
+  .google-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .kakao-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .login-wrap {
+    width: 151px;
+    height: 24px;
+  }
+
+  .guide-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    color: #1f2937;
+  }
+
+  .login-link {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16.71px;
+  }
 }
 
-body {
-  font-family: "Pretendard", sans-serif;
+/* tablet */
+@media (min-width: 768px) {
+  body {
+    padding: 48px 52px 243px;
+  }
+
+  .panda-logo {
+    display: flex;
+    justify-content: center;
+  }
+
+  .panda-logo-link {
+    display: inline-block;
+    width: 396px;
+    height: 132px;
+  }
+
+  main {
+    margin: 40px auto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: none;
+  }
+
+  .form-wrap {
+    width: 640px;
+    color: #1f2937;
+  }
+
+  input {
+    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+  }
+
+  input::placeholder {
+    font-size: 16px;
+    line-height: 26px;
+    color: #9ca3af;
+  }
+
+  input:focus {
+    outline: 1px solid #3692ff;
+  }
+
+  .userEmail-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .email-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
+
+  #userEmail {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .nickname-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .nickname-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
+
+  #nickname {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .password-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
+
+  .input-wrap {
+    position: relative;
+  }
+
+  #password {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    cursor: pointer;
+  }
+
+  .password-check-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+    position: relative;
+  }
+
+  .password-check-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
+
+  #passwordCheck {
+    width: 100%;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
+
+  .password-check-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    cursor: pointer;
+  }
+
+  .signup-button {
+    width: 100%;
+    height: 56px;
+    border-radius: 40px;
+    border-style: none;
+    padding: 16px auto 16px;
+    background-color: #9ca3af;
+    color: #f9fafb;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 32px;
+    text-align: center;
+    margin-bottom: 24px;
+    cursor: pointer;
+  }
+
+  .social-login-wrap {
+    width: 640px;
+    height: 74px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 23px;
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    background-color: #e6f2ff;
+    color: #1f2937;
+    border-radius: 10px;
+  }
+
+  .social-login {
+    display: flex;
+    column-gap: 16px;
+    margin-right: 23px;
+  }
+
+  .google-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .kakao-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .login-wrap {
+    width: 151px;
+    height: 24px;
+  }
+
+  .guide-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    color: #1f2937;
+  }
+
+  .login-link {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16.71px;
+  }
 }
 
-.panda-logo {
-  display: flex;
-  justify-content: center;
-  margin: 60px auto 0;
-}
+/* desktop */
+@media (min-width: 1200px) {
+  body {
+    padding: 60px 0 178px;
+  }
 
-.panda-logo-link {
-  display: inline-block;
-  width: 396px;
-  height: 132px;
-}
+  .panda-logo {
+    display: flex;
+    justify-content: center;
+  }
 
-main {
-  margin: 40px auto 178px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
+  .panda-logo-link {
+    display: inline-block;
+    width: 396px;
+    height: 132px;
+  }
 
-input {
-  padding-top: 16px;
-  padding-bottom: 14px;
-  padding-left: 24px;
-}
+  main {
+    margin: 40px auto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 
-input::placeholder {
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 26px;
-  color: #9ca3af;
-}
+  .form-wrap {
+    width: 640px;
+    color: #1f2937;
+  }
 
-input:focus {
-  outline: 1px solid #3692ff;
-}
+  input {
+    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-left: 24px;
+  }
 
-.userEmail-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-bottom: 24px;
-}
+  input::placeholder {
+    font-size: 16px;
+    line-height: 26px;
+    color: #9ca3af;
+  }
 
-.email-label {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 26px;
-}
+  input:focus {
+    outline: 1px solid #3692ff;
+  }
 
-#userEmail {
-  width: 640px;
-  height: 56px;
-  border-radius: 12px;
-  border-style: none;
-  background-color: #f3f4f6;
-}
+  .userEmail-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
 
-.nickname-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-bottom: 24px;
-}
+  .email-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
 
-.nickname-label {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 26px;
-}
+  #userEmail {
+    width: 640px;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
 
-#nickname {
-  width: 640px;
-  height: 56px;
-  border-radius: 12px;
-  border-style: none;
-  background-color: #f3f4f6;
-}
+  .nickname-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
 
-.password-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-bottom: 24px;
-  position: relative;
-}
+  .nickname-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
 
-.password-label {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 26px;
-}
+  #nickname {
+    width: 640px;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
 
-#password {
-  width: 640px;
-  height: 56px;
-  border-radius: 12px;
-  border-style: none;
-  background-color: #f3f4f6;
-}
+  .password-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
 
-.password-visiblity-button {
-  background-image: url(/images/form/btn-visibility-off.png);
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  right: 24px;
-  bottom: 16px;
-}
+  .password-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
 
-.password-check-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-bottom: 24px;
-  position: relative;
-}
+  .input-wrap {
+    position: relative;
+  }
 
-.password-check-label {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 26px;
-}
+  #password {
+    width: 640px;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
 
-#passwordCheck {
-  width: 640px;
-  height: 56px;
-  border-radius: 12px;
-  border-style: none;
-  background-color: #f3f4f6;
-}
+  .password-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    cursor: pointer;
+  }
 
-.password-check-visiblity-button {
-  background-image: url(/images/form/btn-visibility-off.png);
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  right: 24px;
-  bottom: 16px;
-}
+  .password-check-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 24px;
+    position: relative;
+  }
 
-.signup-button {
-  width: 640px;
-  height: 56px;
-  border-radius: 40px;
-  border-style: none;
-  padding: 16px auto 16px;
-  background-color: #9ca3af;
-  color: #f9fafb;
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 32px;
-  text-align: center;
-  margin-bottom: 24px;
-}
+  .password-check-label {
+    width: fit-content;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 26px;
+  }
 
-.social-login-wrap {
-  width: 640px;
-  height: 74px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-left: 23px;
-  margin-bottom: 24px;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 26px;
-  background-color: #e6f2ff;
-  color: #1f2937;
-  border-radius: 10px;
-}
+  #passwordCheck {
+    width: 640px;
+    height: 56px;
+    padding: 15px 24px;
+    border-radius: 12px;
+    border-style: none;
+    background-color: #f3f4f6;
+  }
 
-.social-login {
-  display: flex;
-  gap: 16px;
-  margin-right: 23px;
-}
+  .password-check-visiblity-button {
+    background-image: url(../images/form/btn-visibility-off.png);
+    background-size: cover;
+    border: 0;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    position: absolute;
+    right: 24px;
+    bottom: 16px;
+    cursor: pointer;
+  }
 
-.google-link {
-  display: inline-block;
-  width: 42px;
-  height: 42px;
-}
+  .signup-button {
+    width: 640px;
+    height: 56px;
+    border-radius: 40px;
+    border-style: none;
+    padding: 16px auto 16px;
+    background-color: #9ca3af;
+    color: #f9fafb;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 32px;
+    text-align: center;
+    margin-bottom: 24px;
+    cursor: pointer;
+  }
 
-.kakao-link {
-  display: inline-block;
-  width: 42px;
-  height: 42px;
-}
+  .social-login-wrap {
+    width: 640px;
+    height: 74px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 23px;
+    margin-bottom: 24px;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 26px;
+    background-color: #e6f2ff;
+    color: #1f2937;
+    border-radius: 10px;
+  }
 
-.login-wrap {
-  width: 151px;
-  height: 24px;
-}
+  .social-login {
+    display: flex;
+    column-gap: 16px;
+    margin-right: 23px;
+  }
 
-.guide-text {
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 24px;
-  color: #1f2937;
-}
+  .google-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
 
-.login-link {
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 16.71px;
+  .kakao-link {
+    display: inline-block;
+    width: 42px;
+    height: 42px;
+  }
+
+  .login-wrap {
+    width: 151px;
+    height: 24px;
+  }
+
+  .guide-text {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    color: #1f2937;
+  }
+
+  .login-link {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16.71px;
+  }
 }


### PR DESCRIPTION
## https://wooy-panda-market.netlify.app/

## 요구사항

• Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
• 피그마 디자인에 맞게 페이지를 만들어 주세요.
• React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 기본

- [x] 공통
    • 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
           - PC: 1200px 이상
           - Tablet: 768px 이상 ~ 1199px 이하
           - Mobile: 375px 이상 ~ 767px 이하
           - 375px 미만 사이즈의 디자인은 고려하지 않습니다
           
- [x] 랜딩 페이지
  • Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.

  • Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.

  • 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

- [x] 로그인, 회원가입 페이지 공통
  • Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
  
  • Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
  
  • Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- 주소와 이미지는 자유롭게 설정하세요.

## 스크린샷

![image](https://github.com/user-attachments/assets/7b0bce57-0c53-46ff-92cd-e602d4f31e38)
![image](https://github.com/user-attachments/assets/a05782e1-aa91-4676-bc2d-e1fe9678e782)

## 멘토에게

- 안녕하세요 멘토님! 이번 미션 반응형 페이지를 하다 보니 css 부분이 많이 꼬인 것 같습니다..
  우선 저 같은 경우에는 mobile-sizie부터 min-width로 범위를 주었는데 그러다보니 tablet-size, desktop-size에도 영향을 주 
  는 side effect(?)가 발생하는 문제점이 생겼습니다. 그렇다면 desktop-size를 먼저 구축했으니 max-width로 해야 했을까요,,? 
  아니면 max-width and min-width 방식으로 하는 것이 나을까요?!
- 저번 미션 때 login.css랑 signup.css랑 겹친는 부분이 있으니 통합하라고 하셨는데, 그럼 현재 두개인 login이랑 signup의 
   css를 하나로 합치라는 말씀이신가요? 

### 파트1 동안 감사했습니다 멘토님