### PR TITLE
[선정민] Sprint3

### DIFF
--- a/common.css
+++ b/common.css
@@ -1,0 +1,32 @@
+:root {
+  /* Gray scale colors */
+  --gray-900: #111827;
+  --gray-800: #1f2937;
+  --gray-700: #374151;
+  --gray-600: #4b5563;
+  --gray-500: #6b7280;
+  --gray-400: #9ca3af;
+  --gray-200: #e5e7eb;
+  --gray-100: #f3f4f6;
+  --gray-50: #f9fafb;
+
+  /* Primary Color */
+  --blue: #3692ef;
+  --banner-bg-color: #cfe5ff;
+
+  /* Error color */
+  --red: #f74747;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  text-decoration: none;
+}
+
+body,
+p {
+  margin: 0;
+}

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="common.css" />
     <link rel="stylesheet" href="style.css" />
     <title>판다마켓</title>
   </head>
@@ -36,7 +37,11 @@
         />
       </section>
       <section class="wrap">
-        <img src="assets/landing/img/Img_home_01.png" alt="Hot Item" />
+        <img
+          src="assets/landing/img/Img_home_01.png"
+          class="content-img"
+          alt="Hot Item"
+        />
         <div class="content">
           <p class="title">Hot Item</p>
           <p class="subtitle">인기 상품을 확인해보세요</p>
@@ -47,7 +52,12 @@
         </div>
       </section>
       <section class="wrap">
-        <div class="content">
+        <img
+          src="assets/landing/img/Img_home_02.png"
+          class="content-img search-img"
+          alt="Search"
+        />
+        <div class="content right">
           <p class="title">Search</p>
           <p class="subtitle">
             구매를 원하는 <br />
@@ -58,10 +68,13 @@
             쉽게 찾아보세요
           </p>
         </div>
-        <img src="assets/landing/img/Img_home_02.png" alt="Search" />
       </section>
       <section class="wrap">
-        <img src="assets/landing/img/Img_home_03.png" alt="Register" />
+        <img
+          src="assets/landing/img/Img_home_03.png"
+          class="content-img"
+          alt="Register"
+        />
         <div class="content">
           <p class="title">Register</p>
           <p class="subtitle">판매를 원하는 <br />상품을 등록하세요</p>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,11 @@
           믿을 수 있는 <br />
           판다마켓 중고거래
         </h1>
-        <img src="assets/landing/img/Img_home_bottom.png" alt="bottom-banner" />
+        <img
+          src="assets/landing/img/Img_home_bottom.png"
+          class="bottom-banner-img"
+          alt="bottom-banner"
+        />
       </section>
     </main>
     <footer>

--- a/login.css
+++ b/login.css
@@ -1,43 +1,9 @@
-:root {
-  /* Gray scale colors */
-  --gray-900: #111827;
-  --gray-800: #1f2937;
-  --gray-700: #374151;
-  --gray-600: #4b5563;
-  --gray-500: #6b7280;
-  --gray-400: #9ca3af;
-  --gray-200: #e5e7eb;
-  --gray-100: #f3f4f6;
-  --gray-50: #f9fafb;
-
-  /* Primary Color */
-  --blue: #3692ef;
-  --banner-bg-color: #cfe5ff;
-
-  /* Error color */
-  --red: #f74747;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-a {
-  text-decoration: none;
-}
-
-body,
-p {
-  margin: 0;
-}
-
 .wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100vh;
   flex-direction: column;
-  margin: 120px 0px;
 }
 
 .logo {
@@ -61,7 +27,7 @@ p {
   display: flex;
   justify-content: center;
   flex-direction: column;
-  width: 640px;
+  width: 780px;
   gap: 24px;
 }
 
@@ -73,7 +39,7 @@ p {
 
 .form input {
   height: 56px;
-  width: 640px;
+  width: 100%;
   border-radius: 12px;
   padding: 16px 24px;
   border: none;
@@ -91,6 +57,8 @@ p {
   font-size: 20px;
   font-weight: 600;
   cursor: pointer;
+  width: 100%; /* 너비를 100%로 조정 */
+  box-sizing: border-box;
 }
 
 .password-input {
@@ -102,8 +70,7 @@ p {
 .btn_visibility {
   cursor: pointer;
   position: absolute;
-  right: 0;
-  margin-right: 10px;
+  right: 16px; /* 위치 조정 */
 }
 
 .social-loginbar {
@@ -111,8 +78,8 @@ p {
   align-items: center;
   justify-content: space-between;
   margin-top: 24px;
-  width: 640px;
-  padding: 16px 24px;
+  width: 780px;
+  padding: 16px;
   background-color: var(--banner-bg-color);
   border-radius: 8px;
   gap: 10px;
@@ -125,9 +92,24 @@ p {
   font-size: 14px;
   line-height: 24px;
   font-weight: 500;
+  padding: 0 16px;
 }
 
 .signup-link {
   color: #3692ef;
   text-decoration: underline;
+}
+
+/* 모바일 사이즈 스타일 */
+@media (max-width: 767px) {
+  .form,
+  .social-loginbar,
+  .form button {
+    width: 100%;
+  }
+
+  .form,
+  .form button {
+    padding: 0 16px;
+  }
 }

--- a/login.html
+++ b/login.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="common.css" />
     <link rel="stylesheet" href="login.css" />
     <title>판다마켓</title>
   </head>
@@ -14,7 +15,7 @@
       </div>
       <form class="form">
         <label for="email">이메일</label>
-        <input type="text" id="email" placeholder="이메일을 입력해주세요." />
+        <input type="email" id="email" placeholder="이메일을 입력해주세요." />
         <label for="password">비밀번호</label>
         <div class="password-input">
           <input
@@ -25,26 +26,26 @@
           <img
             class="btn_visibility"
             src="assets/landing/img/btn_visibility.png"
-            alt="btn_visibility"
+            alt="숨김 버튼 이미지"
           />
         </div>
         <button>로그인</button>
-      </form>
-      <div class="social-loginbar">
-        <span>간편 로그인하기</span>
-        <div class="social-icon">
-          <img
-            class="ic-google"
-            src="assets/landing/icon/google.png"
-            alt="구글 로그인"
-          />
-          <img
-            class="ic-kakaotalk"
-            src="assets/landing/icon/kakaotalk.png"
-            alt="카카오톡 로그인"
-          />
+        <div class="social-loginbar">
+          <span>간편 로그인하기</span>
+          <div class="social-icon">
+            <img
+              class="ic-google"
+              src="assets/landing/icon/google.png"
+              alt="구글 로그인"
+            />
+            <img
+              class="ic-kakaotalk"
+              src="assets/landing/icon/kakaotalk.png"
+              alt="카카오톡 로그인"
+            />
+          </div>
         </div>
-      </div>
+      </form>
       <span class="for-signup">
         판다마켓이 처음이신가요?
         <a class="signup-link" href="signup.html"> 회원가입</a>

--- a/signup.css
+++ b/signup.css
@@ -1,43 +1,9 @@
-:root {
-  /* Gray scale colors */
-  --gray-900: #111827;
-  --gray-800: #1f2937;
-  --gray-700: #374151;
-  --gray-600: #4b5563;
-  --gray-500: #6b7280;
-  --gray-400: #9ca3af;
-  --gray-200: #e5e7eb;
-  --gray-100: #f3f4f6;
-  --gray-50: #f9fafb;
-
-  /* Primary Color */
-  --blue: #3692ef;
-  --banner-bg-color: #cfe5ff;
-
-  /* Error color */
-  --red: #f74747;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-a {
-  text-decoration: none;
-}
-
-body,
-p {
-  margin: 0;
-}
-
 .wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100vh;
   flex-direction: column;
-  margin: 120px 0px;
 }
 
 .logo {
@@ -61,7 +27,7 @@ p {
   display: flex;
   justify-content: center;
   flex-direction: column;
-  width: 640px;
+  width: 780px;
   gap: 24px;
 }
 
@@ -73,7 +39,7 @@ p {
 
 .form input {
   height: 56px;
-  width: 640px;
+  width: 100%;
   border-radius: 12px;
   padding: 16px 24px;
   border: none;
@@ -91,6 +57,8 @@ p {
   font-size: 20px;
   font-weight: 600;
   cursor: pointer;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .password-input {
@@ -102,8 +70,7 @@ p {
 .btn_visibility {
   cursor: pointer;
   position: absolute;
-  right: 0;
-  margin-right: 10px;
+  right: 16px;
 }
 
 .social-loginbar {
@@ -111,7 +78,7 @@ p {
   align-items: center;
   justify-content: space-between;
   margin-top: 24px;
-  width: 640px;
+  width: 100%;
   padding: 16px 24px;
   background-color: var(--banner-bg-color);
   border-radius: 8px;
@@ -131,4 +98,18 @@ p {
 .login-link {
   color: #3692ef;
   text-decoration: underline;
+}
+
+/* 모바일 사이즈 스타일 */
+@media (max-width: 767px) {
+  .form,
+  .social-loginbar,
+  .form button {
+    width: 100%;
+  }
+
+  .form,
+  .form button {
+    padding: 0 16px;
+  }
 }

--- a/signup.html
+++ b/signup.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="common.css" />
     <link rel="stylesheet" href="signup.css" />
     <title>판다 마켓</title>
   </head>
@@ -44,21 +45,21 @@
           />
         </div>
         <button>회원가입</button>
+        <div class="social-loginbar">
+          <span>간편 로그인하기</span>
+          <div class="social-icon">
+            <img
+              class="ic-google"
+              src="assets/landing/icon/google.png"
+              alt="구글 로그인"
+            />
+            <img
+              class="ic-kakaotalk"
+              src="assets/landing/icon/kakaotalk.png"
+              alt="카카오톡 로그인"
+            />
+          </div>
       </form>
-      <div class="social-loginbar">
-        <span>간편 로그인하기</span>
-        <div class="social-icon">
-          <img
-            class="ic-google"
-            src="assets/landing/icon/google.png"
-            alt="구글 로그인"
-          />
-          <img
-            class="ic-kakaotalk"
-            src="assets/landing/icon/kakaotalk.png"
-            alt="카카오톡 로그인"
-          />
-        </div>
       </div>
       <span class="for-login">
         이미 회원이신가요?

--- a/style.css
+++ b/style.css
@@ -3,6 +3,11 @@
   height: auto;
 }
 
+.top-banner-img,
+.bottom-banner-img {
+  width: 100%;
+}
+
 @media (min-width: 375px) {
   .header {
     padding: 12px 16px;

--- a/style.css
+++ b/style.css
@@ -1,41 +1,78 @@
-:root {
-  /* Gray scale colors */
-  --gray-900: #111827;
-  --gray-800: #1f2937;
-  --gray-700: #374151;
-  --gray-600: #4b5563;
-  --gray-500: #6b7280;
-  --gray-400: #9ca3af;
-  --gray-200: #e5e7eb;
-  --gray-100: #f3f4f6;
-  --gray-50: #f9fafb;
-
-  /* Primary Color */
-  --blue: #3692ef;
-  --banner-bg-color: #cfe5ff;
-
-  /* Error color */
-  --red: #f74747;
+.content-img {
+  width: 100%;
+  height: auto;
 }
 
-* {
-  box-sizing: border-box;
+@media (min-width: 375px) {
+  .header {
+    padding: 12px 16px;
+  }
+  .banner {
+    flex-direction: column;
+  }
+
+  .wrap {
+    width: 100%;
+    grid-template-columns: 1fr;
+    padding: 0 16px;
+  }
+
+  .content {
+    margin-top: 10px;
+  }
 }
 
-a {
-  text-decoration: none;
+@media (min-width: 768px) {
+  .header {
+    padding: 12px 24px;
+  }
+
+  .banner {
+    flex-direction: column;
+  }
+
+  .wrap {
+    width: 100%;
+    grid-template-columns: 1fr;
+    padding: 0 24px;
+  }
+
+  .content {
+    margin-top: 20px;
+  }
 }
 
-body,
-p {
-  margin: 0;
+@media (min-width: 1200px) {
+  .header {
+    padding: 12px 100px;
+  }
+
+  .wrap {
+    width: 1200px;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .content.right {
+    grid-row-start: 1;
+  }
+
+  .banner {
+    flex-direction: row;
+  }
+
+  .content.right {
+    padding-right: 100px;
+  }
+
+  .content {
+    padding-left: 100px;
+  }
 }
 
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 200px;
 }
 
 .logo {
@@ -71,10 +108,8 @@ main {
 }
 
 .wrap {
-  width: 1200px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 600px 600px;
 }
 
 .banner {
@@ -99,10 +134,6 @@ main {
   padding-bottom: 8px;
   color: white;
   padding: 12px 100px;
-}
-
-section.wrap img {
-  width: 500px;
 }
 
 section.wrap,
@@ -133,9 +164,8 @@ section.bottom {
   margin: 0;
 }
 
-.content:nth-child(1) {
+.content.right {
   text-align: right;
-  padding-right: 100px;
 }
 
 .description {


### PR DESCRIPTION
### 배포 사이트
https://pandamarket-jm.netlify.app/

## 요구사항
- [x] github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x] 피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x] React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 기본

[공통]
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
- [x] PC: 1200px 이상
- [x] Tablet: 768px 이상 ~ 1199px 이하
- [x] Mobile: 375px 이상 ~ 767px 이하
- [x] 375px 미만 사이즈의 디자인은 고려하지 않습니다
 
[랜딩 페이지]
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

[로그인, 회원가입 페이지 공통]
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

심화
- [] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [] 주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항
- img나 기타 요소들의 width를 고정으로 지정하여 사용하였지만, 이를 width : 100%로 지정하는 것으로 변경하였습니다.
- 여러 css에서 사용하는 공통된 변수들을 따로 별도의 common.css 파일을 생성하여 관리 하였습니다.
- type="email"을 사용하였으며, alt의 경우 이미지를 대체할 수 있도록 유의미한 텍스트로 변경하였습니다.
- wrapper에 적용된 불필요한 margin들을 제거하였습니다. 

## 스크린샷
![127 0 0 1_5500_signup html](https://github.com/user-attachments/assets/23fa4f24-6947-48ec-9455-1d42945469b3)
![127 0 0 1_5500_login html](https://github.com/user-attachments/assets/f67aba48-d95d-45de-84d0-c86297f06769)
![127 0 0 1_5500_index html (2)](https://github.com/user-attachments/assets/40188559-ecdc-44b1-b874-f6102e843ebf)

## 멘토에게

심화 부분은 저번주부터 밀린 수업들을 듣느라 하지 못했습니다 T.T

추가로, 랜딩페이지에서 데스크탑 크기에서 배너가 꾸겨?지는 문제가 있습니다.. 

![image](https://github.com/user-attachments/assets/90991311-66d6-4b6f-8b22-bf40915e7f65)
