### PR TITLE
[김원] Sprint 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
             alt="인기상품"
           />
           <div class="feature-content">
-            <h2 class="feature-tag">Hot item</h2>
-            <h1>
+            <h3 class="feature-tag">Hot item</h3>
+            <h2>
               인기 상품을 <span class="break-on-desktop"><br /></span>확인해
               보세요
-            </h1>
+            </h2>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
@@ -56,11 +56,11 @@
             alt="검색 기능"
           />
           <div class="feature-content">
-            <h2 class="feature-tag">Search</h2>
-            <h1>
+            <h3 class="feature-tag">Search</h3>
+            <h2>
               구매를 원하는 <span class="break-on-desktop"><br /></span>상품을
               검색하세요
-            </h1>
+            </h2>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
@@ -74,11 +74,11 @@
             alt="판매 상품 등록"
           />
           <div class="feature-content">
-            <h2 class="feature-tag">Register</h2>
-            <h1>
+            <h3 class="feature-tag">Register</h3>
+            <h2>
               판매를 원하는 <span class="break-on-desktop"><br /></span>상품을
               등록하세요
-            </h1>
+            </h2>
             <p class="feature-description">
               어떤 물건이든 판매하고 싶은 상품을
               <br />쉽게 등록하세요
@@ -88,7 +88,7 @@
       </section>
       <section id="bottomBanner" class="banner">
         <div class="wrapper">
-          <h1>믿을 수 있는<br />판다마켓 중고거래</h1>
+          <h2>믿을 수 있는<br />판다마켓 중고거래</h2>
         </div>
       </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
             alt="인기상품"
           />
           <div class="feature-content">
-            <h3 class="feature-tag">Hot item</h3>
-            <h2>
+            <div class="feature-tag">Hot item</div>
+            <div class="feature-title">
               인기 상품을 <span class="break-on-desktop"><br /></span>확인해
               보세요
-            </h2>
+            </div>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
@@ -56,11 +56,11 @@
             alt="검색 기능"
           />
           <div class="feature-content">
-            <h3 class="feature-tag">Search</h3>
-            <h2>
+            <div class="feature-tag">Search</div>
+            <div class="feature-title">
               구매를 원하는 <span class="break-on-desktop"><br /></span>상품을
               검색하세요
-            </h2>
+            </div>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
@@ -74,11 +74,11 @@
             alt="판매 상품 등록"
           />
           <div class="feature-content">
-            <h3 class="feature-tag">Register</h3>
-            <h2>
+            <div class="feature-tag">Register</div>
+            <div class="feature-title">
               판매를 원하는 <span class="break-on-desktop"><br /></span>상품을
               등록하세요
-            </h2>
+            </div>
             <p class="feature-description">
               어떤 물건이든 판매하고 싶은 상품을
               <br />쉽게 등록하세요
@@ -88,7 +88,7 @@
       </section>
       <section id="bottomBanner" class="banner">
         <div class="wrapper">
-          <h2>믿을 수 있는<br />판다마켓 중고거래</h2>
+          <div class="bottom-title">믿을 수 있는<br />판다마켓 중고거래</div>
         </div>
       </section>
     </main>

--- a/login.html
+++ b/login.html
@@ -29,7 +29,7 @@
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
 
-      <form id="loginForm" method="post" action="items.html">
+      <form id="loginForm" method="post" action="items">
         <div class="input-item">
           <label for="email">이메일</label>
           <input

--- a/login.html
+++ b/login.html
@@ -18,7 +18,7 @@
     <div class="auth-container">
       <div class="logo-home-button-wrapper">
         <a href="/">
-          <img src="images/login/panda_face.png" />
+          <img class="pandaFace" src="images/login/panda_face.png" />
         </a>
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
@@ -56,8 +56,8 @@
       </form>
 
       <div class="social-login-container">
-        <h3>간편 로그인하기</h3>
-        <div class="social-login-buttons-container">
+        <div class="social-login-title">간편 로그인하기</div>
+        <div class="social-login-buttons">
           <a
             href="https://www.google.com/"
             target="_blank"
@@ -76,7 +76,8 @@
       </div>
 
       <div class="auth-switch">
-        판다마켓이 처음이신가요? <a href="signup.html">회원가입</a>
+        <span>판다마켓이 처음이신가요?</span>
+        <a href="signup.html">회원가입</a>
       </div>
     </div>
   </body>

--- a/login.html
+++ b/login.html
@@ -29,7 +29,7 @@
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
 
-      <form id="submitForm" method="post" action="items.html">
+      <form id="loginForm" method="post" action="items.html">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -50,8 +50,13 @@
               type="password"
               placeholder="비밀번호를 입력해 주세요"
             />
-            <button type="button" class="toggle-password-button">
+            <button
+              id="togglePasswordButton"
+              type="button"
+              class="toggle-password-button"
+            >
               <img
+                id="togglePasswordIcon"
                 src="images/icons/eye-invisible.svg"
                 alt="비밀번호 숨김"
                 class="toggle-password-icon"
@@ -63,10 +68,10 @@
         </div>
 
         <button
-          id="submitButton"
+          id="loginButton"
           type="submit"
           class="button pill-button full-width"
-          onclick="submitForm()"
+          onclick="loginForm()"
         >
           로그인
         </button>

--- a/login.html
+++ b/login.html
@@ -13,6 +13,12 @@
     />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/auth.css" />
+    <script
+      src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
+      integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8="
+      crossorigin="anonymous"
+    ></script>
+    <script src="scripts/auth.js"></script>
   </head>
   <body>
     <div class="auth-container">
@@ -23,7 +29,7 @@
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
 
-      <form method="post">
+      <form id="loginForm" method="post" action="items.html">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -33,6 +39,8 @@
             placeholder="이메일을 입력해주세요"
           />
         </div>
+        <div id="empty-email" class="error-email"></div>
+        <div id="invalid-email" class="error-email"></div>
         <div class="input-item">
           <label for="password">비밀번호</label>
           <div class="input-wrapper">
@@ -48,9 +56,16 @@
               class="toggle-password"
             />
           </div>
+          <div id="empty-password" class="error-password"></div>
+          <div id="short-password" class="error-password"></div>
         </div>
 
-        <button type="submit" class="button pill-button full-width">
+        <button
+          id="loginButton"
+          type="submit"
+          class="button pill-button full-width"
+          onclick="submitLogin()"
+        >
           로그인
         </button>
       </form>

--- a/login.html
+++ b/login.html
@@ -29,7 +29,7 @@
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
 
-      <form id="loginForm" method="post" action="items">
+      <form id="submitForm" method="post" action="items.html">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -63,10 +63,10 @@
         </div>
 
         <button
-          id="loginButton"
+          id="submitButton"
           type="submit"
           class="button pill-button full-width"
-          onclick="submitLogin()"
+          onclick="submitForm()"
         >
           로그인
         </button>

--- a/login.html
+++ b/login.html
@@ -50,11 +50,13 @@
               type="password"
               placeholder="비밀번호를 입력해 주세요"
             />
-            <img
-              src="images/icons/eye-invisible.svg"
-              alt="비밀번호 숨김"
-              class="toggle-password"
-            />
+            <button type="button" class="toggle-password-button">
+              <img
+                src="images/icons/eye-invisible.svg"
+                alt="비밀번호 숨김"
+                class="toggle-password-icon"
+              />
+            </button>
           </div>
           <div id="empty-password" class="error-password"></div>
           <div id="short-password" class="error-password"></div>

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,7 +1,9 @@
 $(function () {
   const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+  const formId = $("form").attr("id");
 
-  $("#submitButton").prop("disabled", true);
+  if (formId === "loginForm") $("#loginButton").prop("disabled", true);
+  else $("#signupButton").prop("disabled", true);
 
   function isValidEmail(email) {
     return emailPattern.test(email);
@@ -80,19 +82,12 @@ $(function () {
       $("#password").removeClass("error-line");
       $("#empty-password").text("");
       $("#short-password").text("");
+      $("#loginButton").prop("disabled", false);
+    } else {
+      $("#loginButton").prop("disabled", true);
     }
 
-    if (e.keyCode === 13) {
-      // enter key(13) 눌렀을 때 이벤트
-      if (!$("#confirmPassword")) {
-        if (
-          isValidEmail($("#email").val()) &&
-          $("#password").val().length >= 7
-        ) {
-          submitLogin();
-        }
-      }
-    }
+    if (formId === "loginForm" && e.keyCode === 13) loginForm();
   });
 
   /* signup page */
@@ -105,26 +100,70 @@ $(function () {
   });
 
   $("input").change(function (e) {
-    if ($("#confirmPassword")) {
+    if (formId === "loginForm") {
+      if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+        $("#loginButton").prop("disabled", false);
+      } else {
+        $("#loginButton").prop("disabled", true);
+      }
+    } else {
       if (
         isValidEmail($("#email").val()) &&
         $("#confirmPassword").val().length >= 8 &&
         $("#password").val() === $("#confirmPassword").val()
       ) {
-        $("#submitButton").prop("disabled", false);
+        $("#signupButton").prop("disabled", false);
       } else {
-        $("#submitButton").prop("disabled", true);
-      }
-    } else {
-      if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
-        $("#submitButton").prop("disabled", false);
-      } else {
-        $("#submitButton").prop("disabled", true);
+        $("#signupButton").prop("disabled", true);
       }
     }
   });
 
-  function submitForm() {
-    $("#submitForm").submit();
+  $("#togglePasswordButton").on("click", function (e) {
+    if ($("#togglePasswordIcon").attr("src").endsWith("eye-invisible.svg")) {
+      $("#togglePasswordIcon").attr("src", "images/icons/eye-visible.svg");
+      $("#password").attr("type", "text");
+    } else {
+      $("#togglePasswordIcon").attr("src", "images/icons/eye-invisible.svg");
+      $("#password").attr("type", "password");
+    }
+  });
+
+  $("#toggleConfirmPasswordButton").on("click", function (e) {
+    if (
+      $("#toggleConfirmPasswordIcon").attr("src").endsWith("eye-invisible.svg")
+    ) {
+      $("#toggleConfirmPasswordIcon").attr(
+        "src",
+        "images/icons/eye-visible.svg"
+      );
+      $("#confirmPassword").attr("type", "text");
+    } else {
+      $("#toggleConfirmPasswordIcon").attr(
+        "src",
+        "images/icons/eye-invisible.svg"
+      );
+      $("#confirmPassword").attr("type", "password");
+    }
+  });
+
+  function loginForm() {
+    if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+      $("#loginForm").submit();
+    } else {
+      $("#loginButton").prop("disabled", true);
+    }
+  }
+
+  function signupForm() {
+    if (
+      isValidEmail($("#email").val()) &&
+      $("#confirmPassword").val().length >= 8 &&
+      $("#password").val() === $("#confirmPassword").val()
+    ) {
+      $("#signupForm").submit();
+    } else {
+      $("#signupButton").prop("disabled", true);
+    }
   }
 });

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,14 +1,14 @@
 $(function () {
   const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
 
-  $("#loginButton").prop("disabled", true);
+  $("#submitButton").prop("disabled", true);
 
   function isValidEmail(email) {
     return emailPattern.test(email);
   }
 
   $("#email").on("focusout", function () {
-    const emailVal = $("#email").val();
+    const emailVal = $("#email").val().trim();
 
     if (!emailVal) {
       $("#email").addClass("error-line");
@@ -25,8 +25,21 @@ $(function () {
     }
   });
 
+  /* signup page */
+  $("#nickname").on("focusout", function () {
+    const nicknameVal = $("#nickname").val().trim();
+
+    if (!nicknameVal) {
+      $("#nickname").addClass("error-line");
+      $("#empty-nickname").text("닉네임을 입력해주세요.");
+    } else {
+      $("#nickname").removeClass("error-line");
+      $("#empty-nickname").text("");
+    }
+  });
+
   $("#password").on("focusout", function () {
-    const passwordVal = $("#password").val();
+    const passwordVal = $("#password").val().trim();
 
     if (!passwordVal) {
       $("#password").addClass("error-line");
@@ -43,24 +56,75 @@ $(function () {
     }
   });
 
+  /* signup page */
+  $("#confirmPassword").on("focusout", function () {
+    const confirmPasswordVal = $("#confirmPassword").val().trim();
+
+    if (!confirmPasswordVal) {
+      $("#confirmPassword").addClass("error-line");
+      $("#empty-confirmPassword").text("비밀번호를 다시 한 번 입력해주세요.");
+      $("#invalid-confirmPassword").text("");
+    } else if (confirmPasswordVal !== $("#password").val()) {
+      $("#confirmPassword").addClass("error-line");
+      $("#empty-confirmPassword").text("");
+      $("#invalid-confirmPassword").text("비밀번호가 일치하지 않습니다.");
+    } else if (confirmPasswordVal === $("#password").val()) {
+      $("#confirmPassword").removeClass("error-line");
+      $("#empty-confirmPassword").text("");
+      $("#invalid-confirmPassword").text("");
+    }
+  });
+
   $("#password").keydown(function (e) {
+    if ($("#password").val().length >= 7) {
+      $("#password").removeClass("error-line");
+      $("#empty-password").text("");
+      $("#short-password").text("");
+    }
+
     if (e.keyCode === 13) {
       // enter key(13) 눌렀을 때 이벤트
-      if (isValidEmail($("#email").val()) && $("#password").val().length >= 7) {
-        submitLogin();
+      if (!$("#confirmPassword")) {
+        if (
+          isValidEmail($("#email").val()) &&
+          $("#password").val().length >= 7
+        ) {
+          submitLogin();
+        }
       }
     }
   });
 
-  $("input").keydown(function (e) {
-    if (isValidEmail($("#email").val()) && $("#password").val().length >= 7) {
-      $("#loginButton").prop("disabled", false);
-    } else {
-      $("#loginButton").prop("disabled", true);
+  /* signup page */
+  $("#confirmPassword").keydown(function (e) {
+    if ($("#confirmPassword").val().length >= 7) {
+      $("#confirmPassword").removeClass("error-line");
+      $("#empty-confirmPassword").text("");
+      $("#invalid-confirmPassword").text("");
     }
   });
 
-  function submitLogin() {
-    $("#loginForm").submit();
+  $("input").change(function (e) {
+    if ($("#confirmPassword")) {
+      if (
+        isValidEmail($("#email").val()) &&
+        $("#confirmPassword").val().length >= 8 &&
+        $("#password").val() === $("#confirmPassword").val()
+      ) {
+        $("#submitButton").prop("disabled", false);
+      } else {
+        $("#submitButton").prop("disabled", true);
+      }
+    } else {
+      if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+        $("#submitButton").prop("disabled", false);
+      } else {
+        $("#submitButton").prop("disabled", true);
+      }
+    }
+  });
+
+  function submitForm() {
+    $("#submitForm").submit();
   }
 });

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -46,14 +46,14 @@ $(function () {
   $("#password").keydown(function (e) {
     if (e.keyCode === 13) {
       // enter key(13) 눌렀을 때 이벤트
-      if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+      if (isValidEmail($("#email").val()) && $("#password").val().length >= 7) {
         submitLogin();
       }
     }
   });
 
   $("input").keydown(function (e) {
-    if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+    if (isValidEmail($("#email").val()) && $("#password").val().length >= 7) {
       $("#loginButton").prop("disabled", false);
     } else {
       $("#loginButton").prop("disabled", true);

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,66 @@
+$(function () {
+  const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+
+  $("#loginButton").prop("disabled", true);
+
+  function isValidEmail(email) {
+    return emailPattern.test(email);
+  }
+
+  $("#email").on("focusout", function () {
+    const emailVal = $("#email").val();
+
+    if (!emailVal) {
+      $("#email").addClass("error-line");
+      $("#empty-email").text("이메일을 입력해주세요.");
+      $("#invalid-email").text("");
+    } else if (!isValidEmail(emailVal)) {
+      $("#email").addClass("error-line");
+      $("#empty-email").text("");
+      $("#invalid-email").text("잘못된 이메일 형식입니다.");
+    } else if (isValidEmail(emailVal)) {
+      $("#email").removeClass("error-line");
+      $("#empty-email").text("");
+      $("#invalid-email").text("");
+    }
+  });
+
+  $("#password").on("focusout", function () {
+    const passwordVal = $("#password").val();
+
+    if (!passwordVal) {
+      $("#password").addClass("error-line");
+      $("#empty-password").text("비밀번호를 입력해주세요.");
+      $("#short-password").text("");
+    } else if (passwordVal.length < 8) {
+      $("#password").addClass("error-line");
+      $("#empty-password").text("");
+      $("#short-password").text("비밀번호를 8자 이상 입력해주세요.");
+    } else if (passwordVal.length >= 8) {
+      $("#password").removeClass("error-line");
+      $("#empty-password").text("");
+      $("#short-password").text("");
+    }
+  });
+
+  $("#password").keydown(function (e) {
+    if (e.keyCode === 13) {
+      // enter key(13) 눌렀을 때 이벤트
+      if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+        submitLogin();
+      }
+    }
+  });
+
+  $("input").keydown(function (e) {
+    if (isValidEmail($("#email").val()) && $("#password").val().length >= 8) {
+      $("#loginButton").prop("disabled", false);
+    } else {
+      $("#loginButton").prop("disabled", true);
+    }
+  });
+
+  function submitLogin() {
+    $("#loginForm").submit();
+  }
+});

--- a/signup.html
+++ b/signup.html
@@ -57,11 +57,13 @@
               type="password"
               placeholder="비밀번호를 입력해 주세요"
             />
-            <img
-              src="images/icons/eye-invisible.svg"
-              alt="비밀번호 숨김"
-              class="toggle-password"
-            />
+            <button type="button" class="toggle-password-button">
+              <img
+                src="images/icons/eye-invisible.svg"
+                alt="비밀번호 숨김"
+                class="toggle-password-icon"
+              />
+            </button>
           </div>
         </div>
         <div class="input-item">
@@ -73,11 +75,13 @@
               type="password"
               placeholder="비밀번호를 다시 한 번 입력해 주세요"
             />
-            <img
-              src="images/icons/eye-invisible.svg"
-              alt="비밀번호 숨김"
-              class="toggle-password"
-            />
+            <button type="button" class="toggle-password-button">
+              <img
+                src="images/icons/eye-invisible.svg"
+                alt="비밀번호 숨김"
+                class="toggle-password-icon"
+              />
+            </button>
           </div>
         </div>
 

--- a/signup.html
+++ b/signup.html
@@ -13,6 +13,12 @@
     />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/auth.css" />
+    <script
+      src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
+      integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8="
+      crossorigin="anonymous"
+    ></script>
+    <script src="scripts/auth.js"></script>
   </head>
   <body>
     <div class="auth-container">

--- a/signup.html
+++ b/signup.html
@@ -29,7 +29,7 @@
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
 
-      <form id="submitForm" method="post" action="login.html">
+      <form id="signupForm" method="post" action="login.html">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -60,8 +60,13 @@
               type="password"
               placeholder="비밀번호를 입력해 주세요"
             />
-            <button type="button" class="toggle-password-button">
+            <button
+              id="togglePasswordButton"
+              type="button"
+              class="toggle-password-button"
+            >
               <img
+                id="togglePasswordIcon"
                 src="images/icons/eye-invisible.svg"
                 alt="비밀번호 숨김"
                 class="toggle-password-icon"
@@ -80,8 +85,13 @@
               type="password"
               placeholder="비밀번호를 다시 한 번 입력해 주세요"
             />
-            <button type="button" class="toggle-password-button">
+            <button
+              id="toggleConfirmPasswordButton"
+              type="button"
+              class="toggle-password-button"
+            >
               <img
+                id="toggleConfirmPasswordIcon"
                 src="images/icons/eye-invisible.svg"
                 alt="비밀번호 숨김"
                 class="toggle-password-icon"
@@ -93,10 +103,10 @@
         </div>
 
         <button
-          id="submitButton"
+          id="signupButton"
           type="submit"
           class="button pill-button full-width"
-          onclick="submitForm()"
+          onclick="signupForm()"
         >
           회원가입
         </button>

--- a/signup.html
+++ b/signup.html
@@ -18,7 +18,7 @@
     <div class="auth-container">
       <div class="logo-home-button-wrapper">
         <a href="/">
-          <img src="images/login/panda_face.png" />
+          <img class="pandaFace" src="images/login/panda_face.png" />
         </a>
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
@@ -81,8 +81,8 @@
       </form>
 
       <div class="social-login-container">
-        <h3>간편 로그인하기</h3>
-        <div class="social-login-buttons-container">
+        <div class="social-login-title">간편 로그인하기</div>
+        <div class="social-login-buttons">
           <a
             href="https://www.google.com/"
             target="_blank"
@@ -101,7 +101,8 @@
       </div>
 
       <div class="auth-switch">
-        이미 회원이신가요? <a href="login.html">로그인</a>
+        <span>이미 회원이신가요?</span>
+        <a href="login.html">로그인</a>
       </div>
     </div>
   </body>

--- a/signup.html
+++ b/signup.html
@@ -29,7 +29,7 @@
         <span class="login-home-text"><a href="/">판다마켓</a></span>
       </div>
 
-      <form method="post">
+      <form id="submitForm" method="post" action="login.html">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -38,6 +38,8 @@
             type="email"
             placeholder="이메일을 입력해 주세요"
           />
+          <div id="empty-email" class="error-email"></div>
+          <div id="invalid-email" class="error-email"></div>
         </div>
         <div class="input-item">
           <label for="nickname">닉네임</label>
@@ -47,6 +49,7 @@
             type="text"
             placeholder="닉네임을 입력해 주세요"
           />
+          <div id="empty-nickname" class="error-nickname"></div>
         </div>
         <div class="input-item">
           <label for="password">비밀번호</label>
@@ -65,13 +68,15 @@
               />
             </button>
           </div>
+          <div id="empty-password" class="error-password"></div>
+          <div id="short-password" class="error-password"></div>
         </div>
         <div class="input-item">
-          <label for="passwordConfirmation">비밀번호 확인</label>
+          <label for="confirmPassword">비밀번호 확인</label>
           <div class="input-wrapper">
             <input
-              id="passwordConfirmation"
-              name="passwordConfirmation"
+              id="confirmPassword"
+              name="confirmPassword"
               type="password"
               placeholder="비밀번호를 다시 한 번 입력해 주세요"
             />
@@ -83,9 +88,16 @@
               />
             </button>
           </div>
+          <div id="empty-confirmPassword" class="error-confirmPassword"></div>
+          <div id="invalid-confirmPassword" class="error-confirmPassword"></div>
         </div>
 
-        <button type="submit" class="button pill-button full-width">
+        <button
+          id="submitButton"
+          type="submit"
+          class="button pill-button full-width"
+          onclick="submitForm()"
+        >
           회원가입
         </button>
       </form>

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -144,6 +144,22 @@ input:focus {
   margin: 0 24px 10px;
 }
 
+.error-nickname {
+  color: var(--red);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0 24px 10px;
+}
+
+.error-confirmPassword {
+  color: var(--red);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0 24px 10px;
+}
+
 /* Tablet */
 @media (min-width: 768px) {
   .pandaFace {

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -1,21 +1,31 @@
 /* Mobile */
 .auth-container {
   max-width: 640px;
+  min-width: 400px;
   margin: 0 auto;
   padding: 16px;
 }
 
 .logo-home-button-wrapper {
-  display: block;
-  text-align: center;
-  margin-top: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 80px;
   margin-bottom: 40px;
+}
+
+.pandaFace {
+  width: 52px;
+  height: 52px;
+  border-radius: 14.5px;
 }
 
 .login-home-text {
   font-family: "ROKAF Sans";
   color: #3692ff;
-  font-size: 68px;
+  font-weight: 700;
+  font-size: 33.17px;
+  line-height: 44.78px;
   padding: 0 20px;
 }
 
@@ -27,9 +37,10 @@
 
 label {
   display: block;
-  margin-bottom: 16px;
-  font-size: 18px;
+  margin-bottom: 10px;
+  font-size: 14px;
   font-weight: 700;
+  line-height: 24px;
 }
 
 input {
@@ -74,25 +85,76 @@ input:focus {
   margin: 24px 0;
 }
 
-.social-login-container h3 {
+.social-login-title {
+  color: var(--gray-800);
   font-weight: 500;
   font-size: 16px;
-  line-height: 24px;
+  line-height: 26px;
 }
 
-.social-login-buttons-container {
+.social-login-buttons {
   display: flex;
   gap: 16px;
 }
 
 .auth-switch {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.auth-switch span {
+  color: var(--gray-800);
   font-weight: 500;
-  font-size: 15px;
+  font-size: 14px;
+  line-height: 24px;
   text-align: center;
+  margin-right: 5px;
 }
 
 .auth-switch a {
-  color: #3182f6;
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+/* Tablet */
+@media (min-width: 768px) {
+  .pandaFace {
+    width: 104px;
+    height: 104px;
+    border-radius: 29px;
+  }
+
+  .login-home-text {
+    font-size: 68px;
+    padding: 0 20px;
+  }
+
+  label {
+    font-size: 16px;
+    line-height: 24px;
+    margin-bottom: 16px;
+  }
+
+  .auth-switch span {
+    font-size: 15px;
+  }
+}
+
+/* Desktop */
+@media (min-width: 1280px) {
+  .login-home-text {
+    font-size: 68px;
+    padding: 0 20px;
+  }
+
+  label {
+    font-size: 16px;
+    line-height: 24px;
+    margin-bottom: 16px;
+  }
+
+  .auth-switch span {
+    font-size: 15px;
+  }
 }

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -2,6 +2,7 @@
 .auth-container {
   max-width: 640px;
   margin: 0 auto;
+  padding: 16px;
 }
 
 .logo-home-button-wrapper {

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -1,3 +1,4 @@
+/* Mobile */
 .auth-container {
   max-width: 640px;
   margin: 0 auto;

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -30,7 +30,7 @@
 }
 
 .input-item {
-  margin-bottom: 24px;
+  margin-bottom: 12px;
   display: flex;
   flex-direction: column;
 }
@@ -60,7 +60,7 @@ input::placeholder {
 }
 
 input:focus {
-  outline-color: var(--blue);
+  outline-color: var(--blue-100);
 }
 
 .input-wrapper {
@@ -115,6 +115,27 @@ input:focus {
 .auth-switch a {
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+.error-line {
+  outline-color: var(--red);
+  outline-style: solid;
+}
+
+.error-email {
+  color: var(--red);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0 24px 10px;
+}
+
+.error-password {
+  color: var(--red);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 24px;
+  margin: 0 24px 10px;
 }
 
 /* Tablet */

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -69,7 +69,13 @@ input:focus {
   align-items: center;
 }
 
-.toggle-password {
+.toggle-password-button {
+  display: flex;
+  justify-self: center;
+  align-items: center;
+}
+
+.toggle-password-icon {
   position: absolute;
   right: 24px;
   cursor: pointer;

--- a/styles/global.css
+++ b/styles/global.css
@@ -7,17 +7,24 @@
 
 :root {
   /* Gray scale */
-  --gray-900: #1b1d1f;
-  --gray-800: #26282b;
-  --gray-600: #454c53;
-  --gray-500: #72787f;
-  --gray-400: #9ea4a8;
+  --gray-900: #111827;
+  --gray-800: #1f2937;
+  --gray-700: #374151;
+  --gray-600: #4b5563;
+  --gray-500: #6b7280;
+  --gray-400: #9ca3af;
   --gray-200: #e5e7eb;
-  --gray-100: #e8ebed;
-  --gray-50: #f7f7f8;
+  --gray-100: #f3f4f6;
+  --gray-50: #f9fafb;
 
   /* Primary color */
-  --blue: #3692ff;
+  --blue-300: #1251aa;
+  --blue-200: #1967d6;
+  --blue-100: #3692ff;
+  --blue-50: #3182f6;
+
+  /* Error color */
+  --red: #f74747;
 
   /* Layout dimensions */
   --header-height: 70px;
@@ -31,7 +38,7 @@
 
 a {
   text-decoration: none;
-  color: inherit;
+  color: var(--blue-50);
 }
 
 button,
@@ -71,7 +78,7 @@ body {
 }
 
 .button {
-  background-color: var(--blue);
+  background-color: var(--blue-100);
   color: #ffffff;
   display: inline-flex;
   align-items: center;
@@ -79,15 +86,15 @@ body {
 }
 
 .button:hover {
-  background-color: #1967d6;
+  background-color: var(--blue-200);
 }
 
 .button:focus {
-  background-color: #1251aa;
+  background-color: var(--blue-300);
 }
 
 .button:disabled {
-  background-color: #9ca3af;
+  background-color: var(--gray-400);
   cursor: default;
   pointer-events: none;
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -65,62 +65,9 @@ body {
   font-family: "Pretendard", sans-serif;
 }
 
-header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: var(--header-height);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0 16px;
-  background-color: #ffffff;
-  border-bottom: 1px solid #dfdfdf;
-}
-
-.mainClass {
-  margin-top: var(--header-height);
-}
-
-footer {
-  background-color: #111827;
-  color: #9ca3af;
-  font-size: 16px;
-  padding: 32px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 60px;
-}
-
-#copyright {
-  order: 3;
-  flex-basis: 100%;
-}
-
-#footerMenu {
-  display: flex;
-  gap: 30px;
-  color: var(--gray-200);
-}
-
-#socialMedia {
-  display: flex;
-  gap: 12px;
-}
-
 .wrapper {
   width: 100%;
   padding: 0 16px;
-}
-
-h1 {
-  font-size: 40px;
-  font-weight: 700;
-  line-height: 56px;
-  letter-spacing: 0.02em;
 }
 
 .button {

--- a/styles/global.css
+++ b/styles/global.css
@@ -109,10 +109,6 @@ body {
 
 /* Tablet */
 @media (min-width: 768px) {
-  header {
-    padding: 0 24px;
-  }
-
   .wrapper {
     padding: 0 24px;
   }
@@ -122,23 +118,10 @@ body {
     font-weight: 700;
     padding: 16px 126px;
   }
-
-  footer {
-    padding: 32px 104px 108px 104px;
-  }
-
-  #copyright {
-    flex-basis: auto;
-    order: 0;
-  }
 }
 
 /* Desktop */
 @media (min-width: 1280px) {
-  header {
-    padding: 0 200px;
-  }
-
   .wrapper {
     max-width: 1200px;
     margin: 0 auto;
@@ -146,9 +129,5 @@ body {
 
   .break-on-desktop {
     display: inline;
-  }
-
-  footer {
-    padding: 32px 200px 108px 200px;
   }
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -1,4 +1,22 @@
 /* Mobile */
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--header-height);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 16px;
+  background-color: #ffffff;
+  border-bottom: 1px solid #dfdfdf;
+}
+
+.mainClass {
+  margin-top: var(--header-height);
+}
+
 .banner {
   text-align: center;
   height: 540px;
@@ -87,6 +105,34 @@
   line-height: 44.8px;
 }
 
+footer {
+  background-color: #111827;
+  color: #9ca3af;
+  font-size: 16px;
+  padding: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 60px;
+}
+
+#copyright {
+  order: 3;
+  flex-basis: 100%;
+}
+
+#footerMenu {
+  display: flex;
+  gap: 30px;
+  color: var(--gray-200);
+}
+
+#socialMedia {
+  display: flex;
+  gap: 12px;
+}
+
 /* Tablet */
 @media (min-width: 768px) {
   .banner {
@@ -164,6 +210,11 @@
     font-weight: 700;
     font-size: 40px;
     line-height: 56px;
+  }
+
+  #copyright {
+    order: inherit;
+    flex-basis: auto;
   }
 }
 

--- a/styles/home.css
+++ b/styles/home.css
@@ -53,7 +53,7 @@
 }
 
 /* 'feature-tag' */
-.feature-content h2 {
+.feature-content h3 {
   color: var(--blue);
   font-size: 16px;
   line-height: 22.4px;
@@ -61,7 +61,7 @@
   margin-bottom: 8px;
 }
 
-.feature-content h1 {
+.feature-content h2 {
   font-weight: 700;
   font-size: 24px;
   line-height: 33.6px;
@@ -115,7 +115,7 @@
   }
 
   /* 'feature-tag' */
-  .feature-content h2 {
+  .feature-content h3 {
     color: var(--blue);
     font-size: 16px;
     line-height: 22.4px;
@@ -123,7 +123,7 @@
     margin-bottom: 8px;
   }
 
-  .feature-content h1 {
+  .feature-content h2 {
     font-weight: 700;
     font-size: 24px;
     line-height: 33.6px;
@@ -179,14 +179,22 @@
     margin-bottom: 0;
   }
 
-  .feature-content h1 {
+  .feature-content h2 {
     font-size: 40px;
     line-height: 56px;
+  }
+
+  .feature-content h3 {
+    font-size: 18px;
   }
 
   .feature-description {
     font-size: 24px;
     line-height: 28.8px;
     margin-top: 24px;
+  }
+
+  #bottomBanner h2 {
+    font-size: 40px;
   }
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -22,6 +22,7 @@
 
 #bottomBanner {
   background-image: url("../images/landing/Img_home_bottom.png");
+  padding: 121px;
 }
 
 #loginLink {
@@ -52,8 +53,7 @@
   flex: 1;
 }
 
-/* 'feature-tag' */
-.feature-content h3 {
+.feature-tag {
   color: var(--blue);
   font-size: 16px;
   line-height: 22.4px;
@@ -61,7 +61,7 @@
   margin-bottom: 8px;
 }
 
-.feature-content h2 {
+.feature-title {
   font-weight: 700;
   font-size: 24px;
   line-height: 33.6px;
@@ -73,6 +73,14 @@
   line-height: 19.2px;
   letter-spacing: 0.08em;
   margin-top: 20px;
+}
+
+.bottom-title {
+  width: 236px;
+  height: 90px;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 44.8px;
 }
 
 /* Tablet */
@@ -114,27 +122,44 @@
     flex: 1;
   }
 
-  /* 'feature-tag' */
-  .feature-content h3 {
+  .feature-tag {
     color: var(--blue);
-    font-size: 16px;
-    line-height: 22.4px;
+    font-size: 18px;
+    line-height: 26px;
     font-weight: 700;
     margin-bottom: 8px;
   }
 
-  .feature-content h2 {
+  .feature-title {
     font-weight: 700;
-    font-size: 24px;
-    line-height: 33.6px;
+    font-size: 32px;
+    line-height: 42px;
   }
 
   .feature-description {
     font-weight: 500;
-    font-size: 16px;
-    line-height: 19.2px;
-    letter-spacing: 0.08em;
+    font-size: 18px;
+    line-height: 26px;
     margin-top: 20px;
+  }
+
+  #bottomBanner {
+    padding: 201px;
+  }
+
+  #bottomBanner .wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .bottom-title {
+    width: 295px;
+    height: 112px;
+    text-align: center;
+    font-weight: 700;
+    font-size: 40px;
+    line-height: 56px;
   }
 }
 
@@ -179,12 +204,12 @@
     margin-bottom: 0;
   }
 
-  .feature-content h2 {
+  .feature-title {
     font-size: 40px;
     line-height: 56px;
   }
 
-  .feature-content h3 {
+  .feature-tag {
     font-size: 18px;
   }
 
@@ -192,9 +217,5 @@
     font-size: 24px;
     line-height: 28.8px;
     margin-top: 24px;
-  }
-
-  #bottomBanner h2 {
-    font-size: 40px;
   }
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -20,11 +20,6 @@
   padding-bottom: 18px;
 }
 
-#bottomBanner {
-  background-image: url("../images/landing/Img_home_bottom.png");
-  padding: 121px;
-}
-
 #loginLink {
   font-size: 16px;
   font-weight: 600;
@@ -73,6 +68,15 @@
   line-height: 19.2px;
   letter-spacing: 0.08em;
   margin-top: 20px;
+}
+
+#bottomBanner {
+  background-image: url("../images/landing/Img_home_bottom.png");
+  padding: 121px;
+}
+
+#bottomBanner .wrapper {
+  display: block;
 }
 
 .bottom-title {
@@ -217,5 +221,18 @@
     font-size: 24px;
     line-height: 28.8px;
     margin-top: 24px;
+  }
+
+  #bottomBanner .wrapper {
+    display: block;
+  }
+
+  .bottom-title {
+    width: 295px;
+    height: 112px;
+    text-align: left;
+    font-weight: 700;
+    font-size: 40px;
+    line-height: 56px;
   }
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -1,11 +1,11 @@
 /* Mobile */
 .banner {
   text-align: center;
-  height: 60vh;
+  height: 540px;
   background-color: #cfe5ff;
   background-repeat: no-repeat;
   background-position: 80% bottom;
-  background-size: 55%;
+  background-size: 448px 204px;
 }
 
 #topBanner {
@@ -78,8 +78,8 @@
 /* Tablet */
 @media (min-width: 768px) {
   .banner {
-    height: 90vh;
-    background-size: 120%;
+    height: 771px;
+    background-size: 744px 340px;
   }
 
   .banner h1 {

--- a/styles/home.css
+++ b/styles/home.css
@@ -1,4 +1,5 @@
 /* Mobile */
+
 header {
   position: fixed;
   top: 0;
@@ -67,7 +68,7 @@ header {
 }
 
 .feature-tag {
-  color: var(--blue);
+  color: var(--blue-100);
   font-size: 16px;
   line-height: 22.4px;
   font-weight: 700;
@@ -177,7 +178,6 @@ footer {
   }
 
   .feature-tag {
-    color: var(--blue);
     font-size: 18px;
     line-height: 26px;
     font-weight: 700;

--- a/styles/home.css
+++ b/styles/home.css
@@ -135,6 +135,10 @@ footer {
 
 /* Tablet */
 @media (min-width: 768px) {
+  header {
+    padding: 0 24px;
+  }
+
   .banner {
     height: 771px;
     background-size: 744px 340px;
@@ -212,14 +216,22 @@ footer {
     line-height: 56px;
   }
 
+  footer {
+    padding: 32px 104px 108px 104px;
+  }
+
   #copyright {
-    order: inherit;
     flex-basis: auto;
+    order: 0;
   }
 }
 
 /* Desktop */
 @media (min-width: 1280px) {
+  header {
+    padding: 0 200px;
+  }
+
   .banner {
     text-align: left;
     height: 540px;
@@ -285,5 +297,9 @@ footer {
     font-weight: 700;
     font-size: 40px;
     line-height: 56px;
+  }
+
+  footer {
+    padding: 32px 200px 108px 200px;
   }
 }


### PR DESCRIPTION
## Netlify
https://pandawon2.netlify.app/

### 기본 요구사항
- Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- 피그마 디자인에 맞게 페이지를 만들어 주세요.
- React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 체크리스트 [기본]

## 로그인/회원가입 공통
- jQuery 를 사용해서 유효성 검사 및 이벤트 처리를 했습니다.
- 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다.
- 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.

## 로그인
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

## 회원가입
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

### 체크리스트 [심화]
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항
- 피드백에 맞게 랜딩/로그인/회원가입 페이지를 Mobile 중심 반응형 페이지로 수정
- jQuery 사용

## 스크린샷
![pandawon2 netlify app_login](https://github.com/user-attachments/assets/3585ceef-b0cb-4028-a85b-6ea9afb5467c)
![pandawon2 netlify app_signup](https://github.com/user-attachments/assets/4fbf4b8f-1e1a-4fca-bd00-6db5bddfd5e7)

## 멘토에게
- 저번 피드백을 최대한 반영해서 모바일 중심 반응형 웹으로 고쳤는데 미흡한 부분 피드백 부탁드립니다.
- 로그인, 회원가입 form method 가 post 여서 그런지 submit 에서 404 에러가 뜹니다. 좋은 해결책이 있을까요?
- 백스페이스 키를 keydown, change 이벤트로 제어하기 어려운거 같습니다. 좋은 해결책이 있을까요?
