### PR TITLE
[구민지] sprint4

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,20 +88,20 @@
   </main>
   <footer>
     <div class="ft_inner">
-      <p>©codeit - 2024</p>
-      <ul>
+      <p class="order-3">©codeit - 2024</p>
+      <ul class="order-1">
         <li><a href="./privacy.html">Privacy Policy</a></li>
         <li><a href="./faq.html">FAQ</a></li>
       </ul>
-      <ul class="sns">
+      <ul class="sns order-2">
         <li><a href="https://www.facebook.com/?locale=ko_KR" target="_blank" rel="noopener noreferrer"><img
-              src="./images/icon/ic_facebook.svg"></a></li>
-        <li><a href="https://x.com/?lang=ko" target="_blank" rel="noopener noreferrer"><img src="./images/icon/ic_twitter.svg"></a>
+              src="./images/icon/ic_facebook.svg" alt="facebook"></a></li>
+        <li><a href="https://x.com/?lang=ko" target="_blank" rel="noopener noreferrer"><img src="./images/icon/ic_twitter.svg" alt="twitter"></a>
         </li>
         <li><a href="https://www.youtube.com/" target="_blank" rel="noopener noreferrer"><img
-              src="./images/icon/ic_youtube.svg"></a></li>
+              src="./images/icon/ic_youtube.svg" alt="youtube"></a></li>
         <li><a href="https://www.instagram.com/" target="_blank" rel="noopener noreferrer"><img
-              src="./images/icon/ic_instagram.svg"></a></li>
+              src="./images/icon/ic_instagram.svg" alt="instagram"></a></li>
       </ul>
     </div>
   </footer>

--- a/login.html
+++ b/login.html
@@ -15,11 +15,12 @@
   <div id="login">
     <div class="wrap_inner2">
       <h1 class="sub_logo"><a href="/" alt="판다마켓"><img src="./images/logo/sub_logo.png" alt="판다마켓"></a></h1>
-      <form action="post">
+      <form action="/items.html">
         <div class="enter_box">
           <div>
             <label for="email">이메일</label>
             <input type="email" name="" value="" id="email" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
+            <div id="error-msg"></div>
           </div>
           <div>
             <label for="password">비밀번호</label>
@@ -27,6 +28,7 @@
               <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 입력해주세요">
               <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
+              <div id="error-msg"></div>
             </div>
           </div>
           <div class="box_btn"><input type="submit" value="로그인"></div>
@@ -42,5 +44,6 @@
       </form>
     </div>
   </div>
+  <script src="/script/auth.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -19,12 +19,12 @@
         <div class="enter_box">
           <div>
             <label for="email">이메일</label>
-            <input type="email" name="" value="" id="" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
+            <input type="email" name="" value="" id="email" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
           </div>
           <div>
             <label for="password">비밀번호</label>
             <div class="pwd_box">
-              <input type="password" name="" value="" id="" class="form_input" autocomplete="new-password"
+              <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 입력해주세요">
               <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
             </div>

--- a/login.html
+++ b/login.html
@@ -27,7 +27,7 @@
             <div class="pwd_box">
               <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 입력해주세요">
-              <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
+              <span class="pwd_icon"><img src="./images/icon/ic_pwd_variant.png" alt="password"></span>
               <div id="error-msg"></div>
             </div>
           </div>

--- a/login.html
+++ b/login.html
@@ -22,7 +22,7 @@
             <input type="email" name="" value="" id="email" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
             <div id="error-msg"></div>
           </div>
-          <div>
+          <div class="pwd-wrapper">
             <label for="password">비밀번호</label>
             <div class="pwd_box">
               <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"

--- a/script/auth.js
+++ b/script/auth.js
@@ -66,10 +66,10 @@ function validateName(){
     const passwordInput = pwdWrapper.querySelector('.form_input');
     if (passwordInput.type === 'password') {
         passwordInput.type = 'text';
-        pwdIconImg.src = './images/icon/ic_pwd_variant.png';
+        pwdIconImg.src = './images/icon/ic_pwd_default.png';
     } else {
         passwordInput.type = 'password';
-        pwdIconImg.src = './images/icon/ic_pwd_default.png';
+        pwdIconImg.src = './images/icon/ic_pwd_variant.png';
     }
   });
 });

--- a/script/auth.js
+++ b/script/auth.js
@@ -11,6 +11,7 @@ function validateInput (inputId , errMsg){
   inputId.closest('div').querySelector('#error-msg').textContent = errMsg;
 }
 
+// 이메일 & 비밀번호 초기화
 function validateInputremove (inputId){
   inputId.classList.remove('input-error');
   inputId.closest('div').querySelector('#error-msg').textContent = '';

--- a/script/auth.js
+++ b/script/auth.js
@@ -2,6 +2,8 @@ const emailInput = document.querySelector('#email');
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const pwdInput = document.querySelector('#password');
 const errBox = document.querySelector('#error-msg');
+const nameInput = document.querySelector('#name');
+const pwdInputChk = document.querySelector('#chk-password');
 
 // 이메일 & 비밀번호 제어
 function validateInput (inputId , errMsg){
@@ -36,11 +38,42 @@ function validatePwd(){
   }
 }
 
-// 이메일 & 비밀번호 호출
-emailInput.addEventListener('focusout',validateEmail);
-pwdInput.addEventListener('focusout',validatePwd);
+// 비밀번호 확인
+function validatePwdChk(){
+  if (pwdInput.value !== pwdInputChk.value){
+    validateInput (pwdInputChk, '비밀번호가 일치하지 않습니다.');
+  } else {
+    validateInputremove (pwdInputChk);
+  }
+}
 
-// 비활성화
+// 닉네임 조건부
+function validateName(){
+  if (nameInput.value === ''){
+    validateInput (nameInput, '닉네임을 입력해주세요.');
+  } else {
+    validateInputremove (nameInput);
+  }
+}
+
+// 비밀번호 노출 제어
+ document.querySelectorAll('.pwd_icon').forEach(pwdIcon => {
+  pwdIcon.addEventListener('click', function(e) {
+    const pwdIcon = e.currentTarget;
+    const pwdIconImg = pwdIcon.querySelector('img');
+    const pwdWrapper = pwdIcon.closest('.pwd-wrapper');
+    const passwordInput = pwdWrapper.querySelector('.form_input');
+    if (passwordInput.type === 'password') {
+        passwordInput.type = 'text';
+        pwdIconImg.src = './images/icon/ic_pwd_variant.png';
+    } else {
+        passwordInput.type = 'password';
+        pwdIconImg.src = './images/icon/ic_pwd_default.png';
+    }
+  });
+});
+
+// 버튼 비활성화
 document.querySelector('form').addEventListener('submit', function(e){
   const inputBox = document.querySelectorAll('.form_input');
   inputBox.forEach((el) => {
@@ -49,3 +82,9 @@ document.querySelector('form').addEventListener('submit', function(e){
     }
   });
 });
+
+// 이메일 & 비밀번호 & 비밀번호 확인 & 닉네임 호출
+emailInput.addEventListener('focusout',validateEmail);
+pwdInput.addEventListener('focusout',validatePwd);
+pwdInputChk.addEventListener('focusout',validatePwdChk);
+nameInput.addEventListener('focusout',validateName);

--- a/script/auth.js
+++ b/script/auth.js
@@ -1,0 +1,51 @@
+const emailInput = document.querySelector('#email');
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const pwdInput = document.querySelector('#password');
+const errBox = document.querySelector('#error-msg');
+
+// 이메일 & 비밀번호 제어
+function validateInput (inputId , errMsg){
+  inputId.classList.add('input-error');
+  inputId.closest('div').querySelector('#error-msg').textContent = errMsg;
+}
+
+function validateInputremove (inputId){
+  inputId.classList.remove('input-error');
+  inputId.closest('div').querySelector('#error-msg').textContent = '';
+}
+
+// 이메일 조건부
+function validateEmail(){
+  if (emailInput.value === ''){
+    validateInput (emailInput, '이메일을 입력해주세요.');
+  } else if (!emailPattern.test(emailInput.value)) {
+    validateInput (emailInput, '잘못된 이메일 형식입니다.');
+  } else {
+    validateInputremove(emailInput);
+  }
+}
+
+// 비밀번호 조건부
+function validatePwd(){
+  if (pwdInput.value === ''){
+    validateInput (pwdInput, '비밀번호를 입력해주세요.');
+  } else if (pwdInput.value.length < 8) {
+    validateInput (pwdInput, '비밀번호를 8자 이상 입력해주세요.');
+  } else {
+    validateInputremove (pwdInput);
+  }
+}
+
+// 이메일 & 비밀번호 호출
+emailInput.addEventListener('focusout',validateEmail);
+pwdInput.addEventListener('focusout',validatePwd);
+
+// 비활성화
+document.querySelector('form').addEventListener('submit', function(e){
+  const inputBox = document.querySelectorAll('.form_input');
+  inputBox.forEach((el) => {
+    if (el.value == '' || errBox.innerText != '' || pwdInput.value.length < 8){
+      e.preventDefault();
+    }
+  });
+});

--- a/signup.html
+++ b/signup.html
@@ -27,7 +27,7 @@
             <input type="name" name="" value="" id="name" class="form_input" placeholder="닉네임을 입력해주세요">
             <div id="error-msg"></div>
           </div>
-          <div>
+          <div class="pwd-wrapper">
             <label for="password">비밀번호</label>
             <div class="pwd_box">
               <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
@@ -36,7 +36,7 @@
               <div id="error-msg"></div>
             </div>
           </div>
-          <div>
+          <div class="pwd-wrapper">
             <label for="chk-password">비밀번호 확인</label>
             <div class="pwd_box">
               <input type="password" name="" value="" id="chk-password" class="form_input" autocomplete="new-password"

--- a/signup.html
+++ b/signup.html
@@ -32,7 +32,7 @@
             <div class="pwd_box">
               <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 입력해주세요">
-              <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
+              <span class="pwd_icon"><img src="./images/icon/ic_pwd_variant.png" alt="password"></span>
               <div id="error-msg"></div>
             </div>
           </div>
@@ -41,7 +41,7 @@
             <div class="pwd_box">
               <input type="password" name="" value="" id="chk-password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 다시 한 번 입력해주세요">
-              <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
+              <span class="pwd_icon"><img src="./images/icon/ic_pwd_variant.png" alt="password"></span>
               <div id="error-msg"></div>
             </div>
           </div>

--- a/signup.html
+++ b/signup.html
@@ -15,7 +15,7 @@
   <div id="signup">
     <div class="wrap_inner2">
       <h1 class="sub_logo"><a href="/" alt="판다마켓"><img src="./images/logo/sub_logo.png" alt="판다마켓"></a></h1>
-      <form action="post">
+      <form action="/signup.html">
         <div class="enter_box">
           <div>
             <label for="email">이메일</label>

--- a/signup.html
+++ b/signup.html
@@ -19,24 +19,24 @@
         <div class="enter_box">
           <div>
             <label for="email">이메일</label>
-            <input type="email" name="" value="" id="" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
+            <input type="email" name="" value="" id="email" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
           </div>
           <div>
             <label for="name">닉네임</label>
-            <input type="name" name="" value="" id="" class="form_input" placeholder="닉네임을 입력해주세요">
+            <input type="name" name="" value="" id="name" class="form_input" placeholder="닉네임을 입력해주세요">
           </div>
           <div>
             <label for="password">비밀번호</label>
             <div class="pwd_box">
-              <input type="password" name="" value="" id="" class="form_input" autocomplete="new-password"
+              <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 입력해주세요">
               <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
             </div>
           </div>
           <div>
-            <label>비밀번호 확인</label>
+            <label for="chk-password">비밀번호 확인</label>
             <div class="pwd_box">
-              <input type="password" name="" value="" id="" class="form_input" autocomplete="new-password"
+              <input type="password" name="" value="" id="chk-password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 다시 한 번 입력해주세요">
               <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
             </div>

--- a/signup.html
+++ b/signup.html
@@ -20,10 +20,12 @@
           <div>
             <label for="email">이메일</label>
             <input type="email" name="" value="" id="email" class="form_input" autocomplete="new-password" placeholder="이메일을 입력해주세요">
+            <div id="error-msg"></div>
           </div>
           <div>
             <label for="name">닉네임</label>
             <input type="name" name="" value="" id="name" class="form_input" placeholder="닉네임을 입력해주세요">
+            <div id="error-msg"></div>
           </div>
           <div>
             <label for="password">비밀번호</label>
@@ -31,6 +33,7 @@
               <input type="password" name="" value="" id="password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 입력해주세요">
               <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
+              <div id="error-msg"></div>
             </div>
           </div>
           <div>
@@ -39,6 +42,7 @@
               <input type="password" name="" value="" id="chk-password" class="form_input" autocomplete="new-password"
                 placeholder="비밀번호를 다시 한 번 입력해주세요">
               <span class="pwd_icon"><img src="./images/icon/ic_pwd_default.png" alt="password"></span>
+              <div id="error-msg"></div>
             </div>
           </div>
           <div class="box_btn"><input type="submit" value="회원가입"></div>
@@ -55,5 +59,6 @@
       </form>
     </div>
   </div>
+  <script src="/script/auth.js"></script>
 </body>
 </html>

--- a/style/auth.css
+++ b/style/auth.css
@@ -15,7 +15,7 @@
 }
 
 .enter_box > div+ div {
-  padding-top: 24px;
+  padding-top: 16px;
 }
 
 .enter_box > div label {
@@ -31,13 +31,12 @@
   position: relative;
 }
 
-.enter_box>div .pwd_box .pwd_icon {
+.enter_box > div .pwd_box .pwd_icon {
   position: absolute;
   right: 24px;
-  top: 50%;
+  top: 16px;
   width: 24px;
   height: auto;
-  margin-top: -12px;
   cursor: pointer;
 }
 
@@ -107,7 +106,7 @@
   border:1px solid var(--color-error);
 }
 #error-msg {
-  padding:8px 16px;
+  margin:8px 16px 0;
   color:var(--color-error);
   font-size:14px;
   font-weight:600;

--- a/style/auth.css
+++ b/style/auth.css
@@ -14,11 +14,11 @@
   padding-top: 40px;
 }
 
-.enter_box>div+div {
+.enter_box > div+ div {
   padding-top: 24px;
 }
 
-.enter_box>div label {
+.enter_box > div label {
   display: block;
   color: var(--color-black);
   font-size: 18px;
@@ -102,6 +102,17 @@
   text-align: center;
 }
 
+/* input error */
+.form_input.input-error {
+  border:1px solid var(--color-error);
+}
+#error-msg {
+  padding:8px 16px;
+  color:var(--color-error);
+  font-size:14px;
+  font-weight:600;
+  text-align:left;
+}
 @media (max-width: 768px) {
   .sub_logo {
     width:198px;

--- a/style/global.css
+++ b/style/global.css
@@ -95,6 +95,7 @@ html {
   --color-bg-footer: #111827;
   --color-bg-input: #F3F4F6;
   --color-bg-sns: #E6F2FF;
+  --color-error: #F74747;
 }
 
 input:focus {

--- a/style/index.css
+++ b/style/index.css
@@ -264,11 +264,12 @@ footer ul li a {
   footer .ft_inner {
     flex-wrap: wrap;
     position:relative;
+    height: 100%;
     padding:8.53%;
+    gap: 60px 0;
   }
-  footer p {
-    position:absolute;
-    left:8.53%;
-    bottom:8.53%;
+  footer .order-3 {
+    order:3;
+    flex:0 0 100%;
   }
 }


### PR DESCRIPTION
https://minjisprint.netlify.app/

## 요구사항
- [x] Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x] 피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x] React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 기본
#### 로그
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
#### 회원가입
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

### 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항
- 없움

## 스크린샷
![image](https://github.com/user-attachments/assets/490266e6-d012-440d-ba16-b18d90c1eb35)

## 멘토에게
- 
