### PR TITLE
[김민준] sprint4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/js/login.js
+++ b/js/login.js
@@ -6,19 +6,23 @@ const errorSpan = document.createElement('span')
 
 const loginbtn = document.querySelector('.form-btn')
 
+const emailChecker = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
 
+// 에러메시지
+function showErrorStatus(input, msg) {
+    input.classList.add('changeRed');
+    errorSpan.textContent = msg
+    errorSpan.classList.add('error-msg')
+}
 
+// 이메일
 function addErrorMessage(e) {
     if (e.target.value === "") {
-        emailInput.classList.add('changeRed');
-        errorSpan.textContent = "이메일을 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(emailInput,"이메일을 입력해주세요.");
         e.target.parentElement.appendChild(errorSpan)
         }
-    else if (!e.target.value.includes("@")) {
-        emailInput.classList.add('changeRed');
-        errorSpan.textContent = "잘못된 이메일 형식입니다"
-        errorSpan.classList.add('error-msg')
+    else if (!e.target.value.includes("@")) {   
+        showErrorStatus(emailInput,"잘못된 이메일 형식입니다")
         e.target.parentElement.appendChild(errorSpan)
     }
     else {
@@ -26,21 +30,14 @@ function addErrorMessage(e) {
         errorSpan.remove(errorSpan)
 }}
 
-
-
-
-
+// 패스워드
 function pwErrorMessage(e) {
     if (e.target.value === "") {
-        passwordInput.classList.add('changeRed');
-        errorSpan.textContent = "비밀번호를 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(passwordInput, "비밀번호를 입력해주세요.")
         e.target.parentElement.appendChild(errorSpan)
         }
     else if (e.target.value.length < 8) {
-        passwordInput.classList.add('changeRed');
-        errorSpan.textContent = "비밀번호를 8자 이상 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(passwordInput, "비밀번호를 8자 이상 입력해주세요.")
         e.target.parentElement.appendChild(errorSpan)
     }
     else {
@@ -48,8 +45,7 @@ function pwErrorMessage(e) {
         errorSpan.remove(errorSpan)
 }}
 
-
-
+// 버튼
 function activeLoginBtn(e) {
     if(emailInput.classList.contains('changeRed') || passwordInput.classList.contains('changeRed')) {
         e.preventDefault(); 

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,61 @@
+const emailInput = document.querySelector('#email')
+const passwordInput = document.querySelector('#password')
+const emailErrorbox = document.querySelector('.input-email')
+const passwordErrorbox = document.querySelector('.input-password')
+const errorSpan = document.createElement('span')
+
+const loginbtn = document.querySelector('.form-btn')
+
+
+
+function addErrorMessage(e) {
+    if (e.target.value === "") {
+        emailInput.classList.add('changeRed');
+        errorSpan.textContent = "이메일을 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+        }
+    else if (!e.target.value.includes("@")) {
+        emailInput.classList.add('changeRed');
+        errorSpan.textContent = "잘못된 이메일 형식입니다"
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+    }
+    else {
+        emailInput.classList.remove('changeRed');
+        errorSpan.remove(errorSpan)
+}}
+
+
+
+
+
+function pwErrorMessage(e) {
+    if (e.target.value === "") {
+        passwordInput.classList.add('changeRed');
+        errorSpan.textContent = "비밀번호를 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+        }
+    else if (e.target.value.length < 8) {
+        passwordInput.classList.add('changeRed');
+        errorSpan.textContent = "비밀번호를 8자 이상 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+    }
+    else {
+        passwordInput.classList.remove('changeRed');
+        errorSpan.remove(errorSpan)
+}}
+
+
+
+function activeLoginBtn(e) {
+    if(emailInput.classList.contains('changeRed') || passwordInput.classList.contains('changeRed')) {
+        e.preventDefault(); 
+} }
+
+
+
+emailInput.addEventListener('focusout', addErrorMessage)
+passwordInput.addEventListener('focusout', pwErrorMessage)

--- a/js/login.js
+++ b/js/login.js
@@ -3,55 +3,57 @@ const passwordInput = document.querySelector('#password')
 const emailErrorbox = document.querySelector('.input-email')
 const passwordErrorbox = document.querySelector('.input-password')
 const errorSpan = document.createElement('span')
-
+const pwErrorSpan = document.createElement('span')
 const loginbtn = document.querySelector('.form-btn')
 
 const emailChecker = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
 
 // 에러메시지
-function showErrorStatus(input, msg) {
+function showErrorStatus(input, span, msg) {
     input.classList.add('changeRed');
-    errorSpan.textContent = msg
-    errorSpan.classList.add('error-msg')
+    span.textContent = msg
+    span.classList.add('error-msg')
 }
 
 // 이메일
 function addErrorMessage(e) {
     if (e.target.value === "") {
-        showErrorStatus(emailInput,"이메일을 입력해주세요.");
+        showErrorStatus(emailInput, errorSpan, "이메일을 입력해주세요.");
         e.target.parentElement.appendChild(errorSpan)
-        }
-    else if (!e.target.value.includes("@")) {   
-        showErrorStatus(emailInput,"잘못된 이메일 형식입니다")
+    } else if (!e.target.value.includes("@")) {
+        showErrorStatus(emailInput, errorSpan, "잘못된 이메일 형식입니다")
         e.target.parentElement.appendChild(errorSpan)
-    }
-    else {
+    } else {
         emailInput.classList.remove('changeRed');
         errorSpan.remove(errorSpan)
-}}
+    }
+}
 
 // 패스워드
 function pwErrorMessage(e) {
     if (e.target.value === "") {
-        showErrorStatus(passwordInput, "비밀번호를 입력해주세요.")
-        e.target.parentElement.appendChild(errorSpan)
-        }
-    else if (e.target.value.length < 8) {
-        showErrorStatus(passwordInput, "비밀번호를 8자 이상 입력해주세요.")
-        e.target.parentElement.appendChild(errorSpan)
-    }
-    else {
+        showErrorStatus(passwordInput, pwErrorSpan, "비밀번호를 입력해주세요.")
+        e.target.parentElement.appendChild(pwErrorSpan)
+    } else if (e.target.value.length < 8) {
+        showErrorStatus(passwordInput, pwErrorSpan, "비밀번호를 8자 이상 입력해주세요.")
+        e.target.parentElement.appendChild(pwErrorSpan)
+    } else {
         passwordInput.classList.remove('changeRed');
-        errorSpan.remove(errorSpan)
-}}
+        pwErrorSpan.remove(pwErrorSpan)
+    }
+}
 
 // 버튼
 function activeLoginBtn(e) {
-    if(emailInput.classList.contains('changeRed') || passwordInput.classList.contains('changeRed')) {
-        e.preventDefault(); 
-} }
+    if (emailInput.classList.contains('changeRed') || passwordInput.classList.contains('changeRed')) {
+        e.preventDefault();
+    } else {
+        window.location.href = "./items.html"
+    }
+}
 
 
 
 emailInput.addEventListener('focusout', addErrorMessage)
 passwordInput.addEventListener('focusout', pwErrorMessage)
+loginbtn.addEventListener('submitm', activeLoginBtn)

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,0 +1,82 @@
+const emailInput = document.querySelector('#email')
+const passwordInput = document.querySelector('#password')
+const emailErrorbox = document.querySelector('.input-email')
+const passwordErrorbox = document.querySelector('.input-password')
+const errorSpan = document.createElement('span')
+
+const loginbtn = document.querySelector('.form-btn')
+
+const nicknameInput = document.querySelector('#nickname')
+const passwordCheckInput = document.querySelector('#password-check')
+
+
+function addErrorMessage(e) {
+    if (e.target.value === "") {
+        emailInput.classList.add('changeRed');
+        errorSpan.textContent = "이메일을 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+        }
+    else if (!e.target.value.includes("@")) {
+        emailInput.classList.add('changeRed');
+        errorSpan.textContent = "잘못된 이메일 형식입니다"
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+    }
+    else {
+        emailInput.classList.remove('changeRed');
+        errorSpan.remove(errorSpan)
+}}
+
+
+
+
+
+function pwErrorMessage(e) {
+    if (e.target.value === "") {
+        passwordInput.classList.add('changeRed');
+        errorSpan.textContent = "비밀번호를 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+        }
+    else if (e.target.value.length < 8) {
+        passwordInput.classList.add('changeRed');
+        errorSpan.textContent = "비밀번호를 8자 이상 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+    }
+    else {
+        passwordInput.classList.remove('changeRed');
+        errorSpan.remove(errorSpan)
+}}
+
+
+function nickNameErrorMessage(e) {
+    if (e.target.value === "") {
+        nicknameInput.classList.add('changeRed');
+        errorSpan.textContent = "닉네임을 입력해주세요."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+        }
+}
+
+function pwcheckErrorMessage(e) {
+    if (e.target.value !== passwordInput.value) {
+        passwordCheckInput.classList.add('changeRed');
+        errorSpan.textContent = "비밀번호가 일치하지 않습니다."
+        errorSpan.classList.add('error-msg')
+        e.target.parentElement.appendChild(errorSpan)
+    }
+}
+
+
+
+
+
+
+
+emailInput.addEventListener('focusout', addErrorMessage)
+passwordInput.addEventListener('focusout', pwErrorMessage)
+nicknameInput.addEventListener('focusout', nickNameErrorMessage)
+passwordCheckInput.addEventListener('focusout', pwcheckErrorMessage)
+

--- a/js/signup.js
+++ b/js/signup.js
@@ -10,39 +10,37 @@ const nicknameInput = document.querySelector('#nickname')
 const passwordCheckInput = document.querySelector('#password-check')
 
 
+
+// 에러메시지
+function showErrorStatus(input, msg) {
+    input.classList.add('changeRed');
+    errorSpan.textContent = msg
+    errorSpan.classList.add('error-msg')
+}
+
+// 이메일
 function addErrorMessage(e) {
     if (e.target.value === "") {
-        emailInput.classList.add('changeRed');
-        errorSpan.textContent = "이메일을 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(emailInput,"이메일을 입력해주세요.");
         e.target.parentElement.appendChild(errorSpan)
         }
-    else if (!e.target.value.includes("@")) {
-        emailInput.classList.add('changeRed');
-        errorSpan.textContent = "잘못된 이메일 형식입니다"
-        errorSpan.classList.add('error-msg')
+    else if (!e.target.value.includes("@")) {   
+        showErrorStatus(emailInput,"잘못된 이메일 형식입니다")
         e.target.parentElement.appendChild(errorSpan)
     }
     else {
         emailInput.classList.remove('changeRed');
         errorSpan.remove(errorSpan)
-}}
-
-
-
-
+    }
+}
 
 function pwErrorMessage(e) {
     if (e.target.value === "") {
-        passwordInput.classList.add('changeRed');
-        errorSpan.textContent = "비밀번호를 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(passwordInput, "비밀번호를 입력해주세요")
         e.target.parentElement.appendChild(errorSpan)
         }
     else if (e.target.value.length < 8) {
-        passwordInput.classList.add('changeRed');
-        errorSpan.textContent = "비밀번호를 8자 이상 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(passwordInput, "비밀번호를 8자 이상 입력해주세요.")
         e.target.parentElement.appendChild(errorSpan)
     }
     else {
@@ -53,18 +51,14 @@ function pwErrorMessage(e) {
 
 function nickNameErrorMessage(e) {
     if (e.target.value === "") {
-        nicknameInput.classList.add('changeRed');
-        errorSpan.textContent = "닉네임을 입력해주세요."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(nicknameInput, "닉네임을 입력해주세요.")
         e.target.parentElement.appendChild(errorSpan)
         }
 }
 
 function pwcheckErrorMessage(e) {
     if (e.target.value !== passwordInput.value) {
-        passwordCheckInput.classList.add('changeRed');
-        errorSpan.textContent = "비밀번호가 일치하지 않습니다."
-        errorSpan.classList.add('error-msg')
+        showErrorStatus(passwordCheckInput, "비밀번호가 일치하지 않습니다.")
         e.target.parentElement.appendChild(errorSpan)
     }
 }

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,65 +1,64 @@
 const emailInput = document.querySelector('#email')
-const passwordInput = document.querySelector('#password')
 const emailErrorbox = document.querySelector('.input-email')
+const passwordInput = document.querySelector('#password')
 const passwordErrorbox = document.querySelector('.input-password')
 const errorSpan = document.createElement('span')
-
+const pwErrorSpan = document.createElement('span')
+const nickNameErrorSpan = document.createElement('span')
+const pwcheckErrorSpan = document.createElement('span')
+const ErrorSpan = document.createElement('span')
 const loginbtn = document.querySelector('.form-btn')
-
 const nicknameInput = document.querySelector('#nickname')
 const passwordCheckInput = document.querySelector('#password-check')
 
-
-
 // 에러메시지
-function showErrorStatus(input, msg) {
+function showErrorStatus(input, span, msg) {
     input.classList.add('changeRed');
-    errorSpan.textContent = msg
-    errorSpan.classList.add('error-msg')
+    span.textContent = msg
+    span.classList.add('error-msg')
 }
 
 // 이메일
 function addErrorMessage(e) {
     if (e.target.value === "") {
-        showErrorStatus(emailInput,"이메일을 입력해주세요.");
+        showErrorStatus(emailInput, errorSpan, "이메일을 입력해주세요.");
         e.target.parentElement.appendChild(errorSpan)
-        }
-    else if (!e.target.value.includes("@")) {   
-        showErrorStatus(emailInput,"잘못된 이메일 형식입니다")
+    } else if (!e.target.value.includes("@")) {
+        showErrorStatus(emailInput, errorSpan, "잘못된 이메일 형식입니다")
         e.target.parentElement.appendChild(errorSpan)
-    }
-    else {
+    } else {
         emailInput.classList.remove('changeRed');
         errorSpan.remove(errorSpan)
     }
 }
 
+// 패스워드
 function pwErrorMessage(e) {
     if (e.target.value === "") {
-        showErrorStatus(passwordInput, "비밀번호를 입력해주세요")
-        e.target.parentElement.appendChild(errorSpan)
-        }
-    else if (e.target.value.length < 8) {
-        showErrorStatus(passwordInput, "비밀번호를 8자 이상 입력해주세요.")
-        e.target.parentElement.appendChild(errorSpan)
-    }
-    else {
+        showErrorStatus(passwordInput, pwErrorSpan, "비밀번호를 입력해주세요.")
+        e.target.parentElement.appendChild(pwErrorSpan)
+    } else if (e.target.value.length < 8) {
+        showErrorStatus(passwordInput, pwErrorSpan, "비밀번호를 8자 이상 입력해주세요.")
+        e.target.parentElement.appendChild(pwErrorSpan)
+    } else {
         passwordInput.classList.remove('changeRed');
-        errorSpan.remove(errorSpan)
-}}
-
-
-function nickNameErrorMessage(e) {
-    if (e.target.value === "") {
-        showErrorStatus(nicknameInput, "닉네임을 입력해주세요.")
-        e.target.parentElement.appendChild(errorSpan)
-        }
+        pwErrorSpan.remove(pwErrorSpan)
+    }
 }
 
+// 닉네임
+function nickNameErrorMessage(e) {
+    if (e.target.value === "") {
+        showErrorStatus(nicknameInput, nickNameErrorSpan, "닉네임을 입력해주세요.")
+        e.target.parentElement.appendChild(nickNameErrorSpan)
+    }
+}
+
+// 패스워드확인
 function pwcheckErrorMessage(e) {
     if (e.target.value !== passwordInput.value) {
-        showErrorStatus(passwordCheckInput, "비밀번호가 일치하지 않습니다.")
-        e.target.parentElement.appendChild(errorSpan)
+        showErrorStatus(passwordCheckInput, pwcheckErrorSpan, "비밀번호가 일치하지 않습니다.")
+        e.target.parentElement.appendChild(pwcheckErrorSpan)
     }
 }
 
@@ -73,4 +72,3 @@ emailInput.addEventListener('focusout', addErrorMessage)
 passwordInput.addEventListener('focusout', pwErrorMessage)
 nicknameInput.addEventListener('focusout', nickNameErrorMessage)
 passwordCheckInput.addEventListener('focusout', pwcheckErrorMessage)
-

--- a/login.css
+++ b/login.css
@@ -32,7 +32,7 @@
     height : 56px;
     border: none;
     border-radius: 12px;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
     padding : 16px 24px 16px 24px;
     gap : 10px;
     background-color: #F3F4F6;
@@ -99,6 +99,23 @@ button:focus {
     background-color: #3692FF;
     border: 1px solid #3692FF;
 }
+
+/* js사용 */
+
+.form-input.changeRed {
+    border: 2px solid red;
+}
+
+.error-msg {
+    font-size: 14px;
+    color : red;
+    text-align: left;
+    font-weight: 700;
+    margin-left: 20px;
+    margin-bottom: 10px;
+    display: block;
+}
+
 
 
 /* 태블릿 사이즈 */

--- a/login.html
+++ b/login.html
@@ -18,13 +18,13 @@
         </header>
         <main>
             <form>
-                <div>
+                <div class="input-email">
                     <label class="form-text" for="email">이메일</label>
                     <input type="email" placeholder="이메일을 입력해주세요" class="form-input" id="email">
                 </div>
-                <div>
+                <div class="input-password">
                     <label class="form-text" for="password">비밀번호</label>
-                    <input type="password" placeholder="비밀번호를 입력해주세요" class="form-input" id="password-input" id="password">
+                    <input type="password" placeholder="비밀번호를 입력해주세요" class="form-input" id="password">
                 </div>
                 <div>
                     <button class="form-btn">로그인</button>
@@ -42,6 +42,7 @@
             <span class="footer-text"> 판다마켓이 처음이신가요?</span>
             <a href="./signup.html">회원가입</a>
         </footer>
+        <script src="./js/login.js"></script>
     </div>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -51,17 +51,6 @@
             <a href="./login.html">로그인</a>
         </footer>
     </div>
+    <script src="js/signup.js"></script>
 </body>
-
-</html><!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>로그인</title>
-    <link rel="stylesheet" href="login.css">
-
-</body>
-
 </html>


### PR DESCRIPTION
## 요구사항

- [x]  Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x]  피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x]  React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 기본
로그인

- [x]  이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x]  비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x]  비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다
- [ ]  input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [ ]  input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [ ]  활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다.

회원가입

- [x]  이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x]  닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x]  비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x]  비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x]  비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [ ]  input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [ ]  input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [ ]  활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다.
### 심화

- [ ] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [ ]  비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항

- 자바스크립트 파일 추가 

## 스크린샷

![image](이미지url)

## 멘토에게

- 버튼활성화 개념이 부족한거 같습니다
- 함수 재사용이 어려운 것 같습니다
- 하다 보니 변수가 너무 많아진것 같습니다
